### PR TITLE
Bug fix for FactorGraph.clone

### DIFF
--- a/mxfusion/components/variables/variable.py
+++ b/mxfusion/components/variables/variable.py
@@ -129,11 +129,11 @@ class Variable(ModelComponent):
             self.isConstant = True
             if isinstance(value, np.ndarray):
                 if shape is not None and shape != value.shape:
-                    raise ModelSpecificationError("Shape mismatch in Variable creation. The numpy array shape " + str(value.shape) + " does not no match with the shape argument " + shape + ".")
+                    raise ModelSpecificationError("Shape mismatch in Variable creation. The numpy array shape " + str(value.shape) + " does not no match with the shape argument " + str(shape) + ".")
                 value = mx.nd.array(value)
             elif isinstance(value, mx.nd.NDArray):
                 if shape is not None and shape != value.shape:
-                    raise ModelSpecificationError("Shape mismatch in Variable creation. The MXNet array shape " + str(value.shape) + " does not no match with the shape argument " + shape + ".")
+                    raise ModelSpecificationError("Shape mismatch in Variable creation. The MXNet array shape " + str(value.shape) + " does not no match with the shape argument " + str(shape) + ".")
             elif isinstance(value, (float, int)):
                 self.shape = (1,)
             self._value = value

--- a/mxfusion/models/factor_graph.py
+++ b/mxfusion/models/factor_graph.py
@@ -373,9 +373,9 @@ class FactorGraph(object):
                 setattr(new_model, v.name, new_leaf)
             else:
                 v.graph = new_model.graph
-        for v in new_model.variables.values():
+        for v in self.variables.values():
             if v.name is not None:
-                setattr(new_model, v.name, v)
+                setattr(new_model, v.name, new_model[v.uuid])
         return new_model, var_map
 
     def get_parameters(self, excluded=None, include_inherited=False):

--- a/testing/core/factor_graph_test.py
+++ b/testing/core/factor_graph_test.py
@@ -137,19 +137,21 @@ class FactorGraphTests(unittest.TestCase):
 
     def test_replicate_simple_model(self):
         m = mf.models.Model(verbose=False)
-        m.x = mfc.Variable()
-        d = mf.components.distributions.Normal(mean=mx.nd.array([0]), variance=mx.nd.array([1e6]))
+        m.x = mfc.Variable(shape=(2,))
+        m.x_mean = mfc.Variable(value=mx.nd.array([0, 1]), shape=(2,))
+        m.x_var = mfc.Variable(value=mx.nd.array([1e6]))
+        d = mf.components.distributions.Normal(mean=m.x_mean, variance=m.x_var)
         m.x.set_prior(d)
         m2, var_map = m.clone()
         # compare m and m2 components and such for exactness.
         self.assertTrue(all([k.uuid == v.uuid for k, v in var_map.items()]))
-        self.assertTrue(all([k.uuid == v.uuid for k, v in
-                        zip(m.components.values(), m2.components.values())]))
+        self.assertTrue(set([v.uuid for v in m.components.values()]) ==
+                        set([v.uuid for v in m2.components.values()]))
         self.assertTrue(all([v in m.components for v in m2.components]), (set(m2.components) - set(m.components)))
         self.assertTrue(all([v in m2.components for v in m.components]), (set(m.components) - set(m2.components)))
-        self.assertTrue(all([self.shape_match(old.shape, new.shape, var_map)
-                        for old, new in
-                        zip(m.variables.values(), m2.variables.values())]))
+        self.assertTrue(all([m.x.shape == m2.x.shape,
+                             m.x_mean.shape == m2.x_mean.shape,
+                             m.x_var.shape == m2.x_var.shape]))
 
     def test_set_prior_after_factor_attach(self):
         fg = mf.models.Model()


### PR DESCRIPTION
* Fix the issue about losing variable name when cloning.
* Fix the random failure of FactorGraphTests.test_replicate_simple_model
* Fix the bug in the error message when creating a variable with a wrong 
shape.

This PR fixes the Issue #8.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
