### PR TITLE
Validate shape of array variables

### DIFF
--- a/mxfusion/components/variables/variable.py
+++ b/mxfusion/components/variables/variable.py
@@ -40,10 +40,12 @@ class Variable(ModelComponent):
     """
     def __init__(self, value=None, shape=None, transformation=None, isInherited=False, initial_value=None):
         super(Variable, self).__init__()
-
-        # TODO If no shape we assume a scalar but this could be incorrect if we really just mean the shape is unknown.
-        self.shape = shape if shape is not None else (1,)
-        self.attributes = [s for s in self.shape if isinstance(s, Variable)]
+        self.shape = shape  # For constants, if shape is None then it is inferred from the value
+        if self.shape is not None:
+            assert isinstance(self.shape, tuple), "Shape is expected to be a tuple or None"
+            self.attributes = [s for s in self.shape if isinstance(s, Variable)]
+        else:
+            self.attributes = []
         # whether the variable is inherited from a Gluon block.
         self.isInherited = isInherited
         self._transformation = transformation
@@ -56,11 +58,11 @@ class Variable(ModelComponent):
         from ...modules.module import Module
         from ..functions.function_evaluation import FunctionEvaluation
         if isinstance(value, (Distribution, Module)):
-            self._initialize_as_randvar(value, shape, transformation)
+            self._initialize_as_randvar(value, self.shape, transformation)
         elif isinstance(value, FunctionEvaluation):
-            self._initialize_as_funcvar(value, shape, transformation)
+            self._initialize_as_funcvar(value, self.shape, transformation)
         else:
-            self._initialize_as_param(value, shape, transformation)
+            self._initialize_as_param(value, self.shape, transformation)
 
     @property
     def type(self):
@@ -128,20 +130,27 @@ class Variable(ModelComponent):
         if value is None:
             # Initialize as VariableType.PARAMETER
             if shape is None:
-                self.shape = (1,)
+                shape = (1,)
         else:
             # Initialize as VariableType.CONSTANT
             self.isConstant = True
             if isinstance(value, np.ndarray):
-                if shape is not None and shape != value.shape:
-                    raise ModelSpecificationError("Shape mismatch in Variable creation. The numpy array shape " + str(value.shape) + " does not no match with the shape argument " + str(shape) + ".")
+                if shape is None:
+                    shape = value.shape
+                if shape != value.shape:
+                    raise ModelSpecificationError("Shape mismatch in Variable creation. The numpy array shape " + str(value.shape) + " does not match with the shape argument " + str(shape) + ".")
                 value = mx.nd.array(value)
             elif isinstance(value, mx.nd.NDArray):
-                if shape is not None and shape != value.shape:
-                    raise ModelSpecificationError("Shape mismatch in Variable creation. The MXNet array shape " + str(value.shape) + " does not no match with the shape argument " + str(shape) + ".")
+                if shape is None:
+                    shape = value.shape
+                if shape != value.shape:
+                    raise ModelSpecificationError("Shape mismatch in Variable creation. The MXNet array shape " + str(value.shape) + " does not match with the shape argument " + str(shape) + ".")
             elif isinstance(value, (float, int)):
-                self.shape = (1,)
+                shape = (1,)
+            else:
+                raise ModelSpecificationError("Variable type {} not supported".format(type(value)))
             self._value = value
+        self.shape = shape  # Update self.shape with the latest shape
 
     def _initialize_as_randvar(self, value, shape, transformation):
         if transformation is not None:

--- a/testing/core/variable_test.py
+++ b/testing/core/variable_test.py
@@ -1,7 +1,9 @@
 import unittest
 import mxnet as mx
+import numpy as np
 import mxfusion.components as mfc
 import mxfusion as mf
+import mxfusion.common.exceptions as mf_exception
 
 
 class VariableTests(unittest.TestCase):
@@ -40,3 +42,26 @@ class VariableTests(unittest.TestCase):
         self.assertTrue(x2.uuid == m.x.uuid)
         self.assertTrue(x2.shape == m.x.shape, (x2.shape, m.x.shape))
         self.assertTrue(y in m)
+
+    def test_array_variable_shape(self):
+        mxnet_array_shape = (3, 2)
+        numpy_array_shape = (10, )
+        mxnet_array = mx.nd.zeros(shape=mxnet_array_shape)
+        numpy_array = np.zeros(shape=numpy_array_shape)
+
+        # Test Case 1: Shape param not explicitly passed to Variable class
+        variable = mf.Variable(value=mxnet_array)
+        self.assertTrue(variable.shape == mxnet_array_shape)
+        variable = mf.Variable(value=numpy_array)
+        self.assertTrue(variable.shape == numpy_array_shape)
+
+        # Test Case 2: Correct shape passed to Variable class
+        variable = mf.Variable(value=mxnet_array, shape=mxnet_array_shape)
+        self.assertTrue(variable.shape == mxnet_array_shape)
+        variable = mf.Variable(value=numpy_array, shape=numpy_array_shape)
+        self.assertTrue(variable.shape == numpy_array_shape)
+
+        # Test Case 3: Incorrect shape passed to Variable class
+        incorrect_shape = (1234, 1234)
+        self.assertRaises(mf_exception.ModelSpecificationError, mf.Variable, value=mxnet_array, shape=incorrect_shape)
+        self.assertRaises(mf_exception.ModelSpecificationError, mf.Variable, value=numpy_array, shape=incorrect_shape)


### PR DESCRIPTION
*Issue:*

- When an MXFusion Variable is created using MXNet ndarray or Numpy array, shape passed is not validated, resulting in incorrect shape being assigned to  the Variable object.
- If the shape if None, Variable's shape is defaulted to (1, ) which could be incorrect based on the value passed.

Example:
`
data = mxfusion.Variable(value=mx.nd.zeros(shape=(3,2)))
print(data.shape)  # Prints (1, ) which is incorrect
`

*Description of changes:*
- Assign the correct shape for array variables when shape passed is None.
- Make existing shape validation checks to run in all code paths.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
