### PR TITLE
Fix divide by zero error if max_iter < n_prints

### DIFF
--- a/mxfusion/inference/batch_loop.py
+++ b/mxfusion/inference/batch_loop.py
@@ -31,7 +31,7 @@ class BatchInferenceLoop(GradLoop):
                                    optimizer=optimizer,
                                    optimizer_params={'learning_rate':
                                                      learning_rate})
-        iter_step = max_iter // n_prints
+        iter_step = max(max_iter // n_prints, 1)
         for i in range(max_iter):
             with mx.autograd.record():
                 loss, loss_for_gradient = infr_executor(mx.nd.zeros(1, ctx=ctx), *data)


### PR DESCRIPTION
Fix a bug where `iter_step` ends up being zero if there are fewer iterations than print steps


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
