### PR TITLE
 Fix bug to allow the same variable for multiple inputs to a factor 

### DIFF
--- a/mxfusion/components/factor.py
+++ b/mxfusion/components/factor.py
@@ -150,7 +150,7 @@ class Factor(ModelComponent):
         Return a list of nodes whose edges point into this node.
         """
         if self.graph is not None:
-            pred = {e['name']: v for v, e in self.graph.pred[self].items()}
+            pred = {e['name']: v for v, edges in self.graph.pred[self].items() for e in edges.values()}
             return [(name, pred[name]) for name in self.input_names]
         else:
             return self._predecessors
@@ -161,7 +161,7 @@ class Factor(ModelComponent):
         Return a list of nodes pointed to by the edges of this node.
         """
         if self.graph is not None:
-            succ = {e['name']: v for v, e in self.graph.succ[self].items()}
+            succ = {e['name']: v for v, edges in self.graph.succ[self].items() for e in edges.values()}
             return [(name, succ[name]) for name in self.output_names]
         else:
             return self._successors

--- a/mxfusion/components/model_component.py
+++ b/mxfusion/components/model_component.py
@@ -129,7 +129,7 @@ class ModelComponent(object):
         Note: The ordering of this list is not guaranteed to be consistent with assigned order.
         """
         if self.graph is not None:
-            succ = [(e['name'], v) for v, e in self.graph.succ[self].items()]
+            succ = [(e['name'], v) for v, edges in self.graph.succ[self].items() for e in edges.values()]
             return succ
         else:
             return self._successors
@@ -154,7 +154,7 @@ class ModelComponent(object):
                 self.graph.remove_edge(self, successor)
             for name, successor in successors:
                 successor.graph = self.graph
-                self.graph.add_edge(self, successor, name=name)
+                self.graph.add_edge(self, successor, key=name, name=name)
         else:
             self._successors = successors
             for name, successor in successors:
@@ -169,7 +169,7 @@ class ModelComponent(object):
         Note: The ordering of this list is not guaranteed to be consistent with assigned order.
         """
         if self.graph is not None:
-            pred = [(e['name'], v) for v, e in self.graph.pred[self].items()]
+            pred = [(e['name'], v) for v, edges in self.graph.pred[self].items() for e in edges.values()]
             return pred
         else:
             return self._predecessors
@@ -194,7 +194,7 @@ class ModelComponent(object):
                 self.graph.remove_edge(predecessor, self)
             for name, predecessor in predecessors:
                 predecessor.graph = self.graph
-                self.graph.add_edge(predecessor, self, name=name)
+                self.graph.add_edge(predecessor, self, key=name, name=name)
         else:
             self._predecessors = predecessors
             for name, predecessor in predecessors:

--- a/mxfusion/models/factor_graph.py
+++ b/mxfusion/models/factor_graph.py
@@ -43,7 +43,7 @@ class FactorGraph(object):
         self._uuid = str(uuid4())
         self._var_ties = {}
 
-        self._components_graph = nx.DiGraph()
+        self._components_graph = nx.MultiDiGraph()
         self._verbose = verbose
 
     def __repr__(self):

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -4,7 +4,7 @@ flake8>=3.5.0
 pytest>=3.5.1
 pytest-cov>=2.5.1
 scipy>=1.1.0
-GPy>=1.8.5
+GPy>=1.9.6
 matplotlib
 scikit-learn>=0.20.0
 mxnet>=1.3

--- a/testing/components/model_component_test.py
+++ b/testing/components/model_component_test.py
@@ -34,7 +34,7 @@ class ModelComponentTests(unittest.TestCase):
         #
         # successors = set([(node_b.uuid, node_a.uuid), (node_c.uuid, node_a.uuid)])
 
-        graph = nx.DiGraph()
+        graph = nx.MultiDiGraph()
 
         node_a.graph = graph
 
@@ -51,7 +51,7 @@ class ModelComponentTests(unittest.TestCase):
         node_b.successors = [('edge_1', node_a)]
         node_c.successors = [('edge_2', node_a)]
 
-        graph = nx.DiGraph()
+        graph = nx.MultiDiGraph()
 
         node_c.graph = graph
 
@@ -69,7 +69,7 @@ class ModelComponentTests(unittest.TestCase):
         node_a.predecessors = [('edge_1', node_b), ('edge_2', node_c)]
         node_b.predecessors = [('edge_1', node_d), ('edge_2', node_e)]
 
-        graph = nx.DiGraph()
+        graph = nx.MultiDiGraph()
 
         node_a.graph = graph
 
@@ -84,7 +84,7 @@ class ModelComponentTests(unittest.TestCase):
     def test_join_attach_new_successor_not_to_graph(self):
 
         node_a = mfc.ModelComponent()
-        graph = nx.DiGraph()
+        graph = nx.MultiDiGraph()
 
         node_b = mfc.ModelComponent()
         node_d = mfc.ModelComponent()
@@ -107,7 +107,7 @@ class ModelComponentTests(unittest.TestCase):
     def test_join_predecessors_not_in_graph_to_node_in_graph(self):
 
         node_a = mfc.ModelComponent()
-        graph = nx.DiGraph()
+        graph = nx.MultiDiGraph()
         node_a.graph = graph
 
         node_b = mfc.ModelComponent()
@@ -130,7 +130,7 @@ class ModelComponentTests(unittest.TestCase):
         node_d = mfc.ModelComponent()
         node_e = mfc.ModelComponent()
         node_b.successors = [('edge_1', node_d), ('edge_2', node_e)]
-        graph = nx.DiGraph()
+        graph = nx.MultiDiGraph()
 
         node_a.graph = graph
         node_a.successors = [('edge_1', node_b)]
@@ -148,7 +148,7 @@ class ModelComponentTests(unittest.TestCase):
         node_c = mfc.ModelComponent()
         node_a.predecessors = [('edge_1', node_b), ('edge_1', node_c)]
 
-        graph = nx.DiGraph()
+        graph = nx.MultiDiGraph()
 
         node_a.graph = graph
 

--- a/testing/models/factor_graph_test.py
+++ b/testing/models/factor_graph_test.py
@@ -198,6 +198,27 @@ class FactorGraphTests(unittest.TestCase):
         self.assertTrue(set([v for _, v in x.predecessors]) == set([d]))
         self.assertTrue(x.graph == d.graph and d.graph == fg.components_graph)
 
+    def test_same_variable_as_multiple_inputs_to_factor_in_graph(self):
+        fg = mf.models.Model()
+
+        fg.x = mfc.Variable()
+        fg.y = mf.components.distributions.Normal.define_variable(mean=fg.x, variance=fg.x)
+
+        self.assertTrue(set([v for _, v in fg.y.factor.predecessors]) == set([fg.x]))
+        self.assertTrue(set([v for _, v in fg.x.successors]) == set([fg.y.factor]))
+        self.assertTrue(len(fg.y.factor.predecessors) == 2)
+        self.assertTrue(len(fg.x.successors) == 2)
+
+    def test_same_variable_as_multiple_inputs_to_factor_not_in_graph(self):
+
+        x = mfc.Variable()
+        y = mf.components.distributions.Normal.define_variable(mean=x, variance=x)
+
+        self.assertTrue(set([v for _, v in y.factor.predecessors]) == set([x]))
+        self.assertTrue(set([v for _, v in x.successors]) == set([y.factor]))
+        self.assertTrue(len(y.factor.predecessors) == 2)
+        self.assertTrue(len(x.successors) == 2)
+
     def test_compute_log_prob(self):
         m = Model()
         v = Variable(shape=(1,))


### PR DESCRIPTION
*Issue #40 *

*Description of changes:*
Change FactorGraph to use the MultiDiGraph class instead of DiGraph, which allows parallel edges. Some minor changes in how we handle the additional parallel edge data structure in the ModelComponent and Factor classes as well.

Added a test case to test multiple inputs that are the same variable, both when attached to a graph and when not.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
