### PR TITLE
Removed osx versions 3.4.4 and 3.5.1 from travis to speed up deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,12 +35,6 @@ jobs:
   include:
   - os: osx
     language: generic
-    env: PYTHON=3.4.4
-  - os: osx
-    language: generic
-    env: PYTHON=3.5.1
-  - os: osx
-    language: generic
     env: PYTHON=3.6.6
 
   - stage: release


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
