### PR TITLE
Add MCMC Sampling

### DIFF
--- a/docs/design_proposals/design_2_mcmc.md
+++ b/docs/design_proposals/design_2_mcmc.md
@@ -1,0 +1,36 @@
+# Possible design extensions to support MCMC sampling algorithms
+
+Eric Meissner(2018-11-12)
+
+## Motivation
+
+To support the first MCMC (Markov-Chain Monte Carlo) inference algorithm in MXFusion, a few issues need to be resolved. These are primarily due to the Markovian part of MCMC, requiring a one-step time series style approach to generate proposal samples from the previous samples. This document discusses designs for those issues that are extensible to future MCMC algorithms, but don't necessarily solve the complete set of time-series modelling issues. I will take the Metropolis-Hastings algorithm as standard in this document, as that's the first MCMC inference we'll be implementing and it is more general(and more difficult to implement in MXFusion) than say Gibbs sampling or Hamiltonian Monte Carlo.
+
+### Problem Setup
+The two primary design choices to be made are:
+1. Where are MCMC samples stored / transferred to future inference algorithms? What is the interface for this, and how are they initialized?
+2. How do we take most recent sample in the chain, ```z_t```, and use it to generate the next sample ```z_t+1```.
+ * This is non-trivial in MXFusion because it builds a circular reference into the proposal's FactorGraph. ```z_t+1``` depends on ```z_t``` but for a Model (without time-series support) saying a Variable depends on itself, ```m.z = Distribution(inputs=[m.z, ...]```, doesn't work right now.
+
+
+## Proposed Changes
+
+
+For problem (1), I propose we extend the InferenceParameters class (either as a subclass or a flag during initialization controlled by the Inference method) to include storing parameters for latent variables (LV), which is what the output samples of an MCMC algorithm are. Throughout the Inference method, these LV parameters would keep an up-to-date list of samples generated. In this solution, MCMC samples are easily serialized with no extra effort, and the existing TransferInference class can be extended readily to support reuse of these samples in later algorithms.
+* Downside: This doesn't out-of-the-box allow for things like multi-chain generation and storage without storing the parameters elsewhere outside of the Inference loop, but that could easily be added in the future as needed. Another downside is that it complicates the InferenceParameters a bit, but either introducing subclasses or a flag that changes the behavior to include LV generation, and InferenceParameters
+
+For problem (2), I propose:
+* Developing the InferenceAlgorithm.compute() method as a method that takes in variables (LVs ```theta_t``` and parameters) for timestep ```t``` and outputs the samples for the LVs for the next timestep in the chain ```t+1``` (```theta_t+1```).
+* The Inference class handles initializing parameters and LVs for ```t=0```, calling the InferenceAlgorithm.compute() in a loop for the number of samples requested, and managing the correct timestep of LV sample values that are passed into InferenceAlgorithm.compute().
+* Treat the proposal distribution as a Posterior FactorGraph, leveraging the standard draw_samples and log_pdf methods.
+* Introducing mapping variables into this proposal distribution that cut the connections needed to go from ```theta_t``` to ```theta_t+1```.
+ * The transfer of values one timestep to the next for LVs (i.e. to generate a sample at timestep ```3```, it needs as input the sample from timestep ```2``` which was the output at that timestep) is handled in the Inference class.
+
+ A working proof of concept is attached in the original pull request for this. It does not have a correctly extended InferenceParameters class, nor does it store the sample values in InferenceParameters directly. It successfully trained the Getting Started tutorial and the PPCA tutorial after adding a prior to ```m.w``` and using ```variance=1e-4``` for the proposal distributions.
+
+
+## Rejected Alternatives
+
+An alternative solution to problem (1) is to not store the MCMC samples at all in the Inference object, and simply return the samples after the Inference method completes. The main downsides to this are that the user then has to maintain those samples for use in future algorithms, and manually serialize those samples. I also don't see an easy alternative solution to the problem of initializing/storing the latent variables correctly **during Inference** without replicated code from InferenceParameters needing to go into the MCMCInference class.
+
+An alternative solution to problem (2) is ...

--- a/mxfusion/components/distributions/distribution.py
+++ b/mxfusion/components/distributions/distribution.py
@@ -55,7 +55,7 @@ class Distribution(Factor):
 
     def log_pdf(self, F, variables, targets=None):
         """
-        Computes the logarithm of the probability density/mass function (PDF/PMF) of the distribution. 
+        Computes the logarithm of the probability density/mass function (PDF/PMF) of the distribution.
         The inputs and outputs variables are fetched from the *variables* argument according to their UUIDs.
 
         :param F: the MXNet computation mode (mxnet.symbol or mxnet.ndarray).

--- a/mxfusion/inference/inference.py
+++ b/mxfusion/inference/inference.py
@@ -43,7 +43,8 @@ class Inference(object):
     """
 
     def __init__(self, inference_algorithm, constants=None,
-                 hybridize=False, dtype=None, context=None):
+                 hybridize=False, dtype=None, context=None,
+                 is_mcmc=False):
 
         self.dtype = dtype if dtype is not None else get_default_dtype()
         self.mxnet_context = context if context is not None else get_default_device()
@@ -52,13 +53,14 @@ class Inference(object):
         self._inference_algorithm = inference_algorithm
         self.params = InferenceParameters(constants=constants,
                                           dtype=self.dtype,
-                                          context=self.mxnet_context)
+                                          context=self.mxnet_context,
+                                          is_mcmc=is_mcmc)
         self._initialized = False
 
     def print_params(self):
         """
         Returns a string with the inference parameters nicely formatted for display, showing which model they came from and their name + uuid.
-        
+
         Format:
         > infr.print_params()
         Variable(1ab23)(name=y) - (Model/Posterior(123ge2)) - (first mxnet values/shape)

--- a/mxfusion/inference/inference_parameters.py
+++ b/mxfusion/inference/inference_parameters.py
@@ -85,8 +85,9 @@ class InferenceParameters(object):
                 self._constants[var.uuid] = var.constant
 
             excluded = set(self._constants.keys()).union(observed_uuid)
-            for var in g.get_parameters(excluded=excluded,
-                                        include_inherited=False):
+            to_init = g.get_parameters(excluded=excluded,
+                                        include_inherited=False) + g.get_latent_variables(observed_uuid)
+            for var in to_init:
                 var_shape = realize_shape(var.shape, self._constants)
                 init = initializer.Constant(var.initial_value_before_transformation) \
                     if var.initial_value is not None else None

--- a/mxfusion/inference/inference_parameters.py
+++ b/mxfusion/inference/inference_parameters.py
@@ -40,7 +40,7 @@ class InferenceParameters(object):
     :param context: The MXNet context
     :type context: {mxnet.cpu or mxnet.gpu}
     """
-    def __init__(self, constants=None, dtype=None, context=None):
+    def __init__(self, constants=None, dtype=None, context=None, is_mcmc=False):
         self.dtype = dtype if dtype is not None else get_default_dtype()
         self.mxnet_context = context if context is not None else get_default_device()
         self._constants = {}
@@ -51,6 +51,7 @@ class InferenceParameters(object):
                 for k, v in constants.items()}
             self._constants.update(constant_uuids)
         self._params = ParameterDict()
+        self._is_mcmc = is_mcmc
 
     def update_constants(self, constants):
         """
@@ -86,9 +87,11 @@ class InferenceParameters(object):
 
             excluded = set(self._constants.keys()).union(observed_uuid)
             to_init = g.get_parameters(excluded=excluded,
-                                        include_inherited=False) + g.get_latent_variables(observed_uuid)
+                                        include_inherited=False)
+            if self._is_mcmc:
+                to_init = to_init + g.get_latent_variables(observed_uuid)
             for var in set(to_init):
-                if var in self._params:
+                if self._is_mcmc and var in self._params:
                     continue
                 var_shape = realize_shape(var.shape, self._constants)
                 init = initializer.Constant(var.initial_value_before_transformation) \

--- a/mxfusion/inference/inference_parameters.py
+++ b/mxfusion/inference/inference_parameters.py
@@ -87,7 +87,9 @@ class InferenceParameters(object):
             excluded = set(self._constants.keys()).union(observed_uuid)
             to_init = g.get_parameters(excluded=excluded,
                                         include_inherited=False) + g.get_latent_variables(observed_uuid)
-            for var in to_init:
+            for var in set(to_init):
+                if var in self._params:
+                    continue
                 var_shape = realize_shape(var.shape, self._constants)
                 init = initializer.Constant(var.initial_value_before_transformation) \
                     if var.initial_value is not None else None

--- a/mxfusion/inference/mh_sampling.py
+++ b/mxfusion/inference/mh_sampling.py
@@ -130,7 +130,7 @@ class MCMCInference(Inference):
                  hybridize=False, dtype=None, context=None):
         super(MCMCInference, self).__init__(
             inference_algorithm=inference_algorithm, constants=constants,
-            hybridize=hybridize, dtype=dtype, context=context)
+            hybridize=hybridize, dtype=dtype, context=context, is_mcmc=True)
         self._number_proposals = 0
         self.samples = {}
 

--- a/mxfusion/inference/mh_sampling.py
+++ b/mxfusion/inference/mh_sampling.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License").
+#   You may not use this file except in compliance with the License.
+#   A copy of the License is located at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   or in the "license" file accompanying this file. This file is distributed
+#   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+#   express or implied. See the License for the specific language governing
+#   permissions and limitations under the License.
+# ==============================================================================
 
 from ..common.exceptions import InferenceError
 from ..common.config import DEFAULT_DTYPE

--- a/mxfusion/inference/mh_sampling.py
+++ b/mxfusion/inference/mh_sampling.py
@@ -1,0 +1,172 @@
+
+from ..common.exceptions import InferenceError
+from ..common.config import DEFAULT_DTYPE
+from ..components.variables import Variable
+from .variational import StochasticVariationalInference
+from .inference_alg import SamplingAlgorithm
+from .inference import Inference
+from .map import MAP
+from ..components.distributions import Normal
+from ..models import Posterior
+import mxnet as mx
+from ..components.distributions.random_gen import MXNetRandomGenerator
+
+class MetropolisHastingsAlgorithm(SamplingAlgorithm):
+    """
+    The Metropolis-Hastings MCMCsampling algorithm.
+
+    :param model: the definition of the probabilistic model
+    :type model: Model
+    :param proposal: the proposal distribution to draw comparison samples against.
+    :type proposal: Distribution
+    :param observed: A list of observed variables
+    :type observed: [Variable]
+    :param num_samples: the number of samples used in estimating the variational lower bound
+    :type num_samples: int
+    :param target_variables: (optional) the target variables to sample
+    :type target_variables: [UUID]
+    """
+    def __init__(self, model, observed, proposal=None, num_samples=1,
+                 target_variables=None, variance=None, rand_gen=None, dtype=None):
+        self._rand_gen = MXNetRandomGenerator if rand_gen is None else \
+            rand_gen
+        self._dtype = dtype if dtype is not None else DEFAULT_DTYPE
+        self._map = {}
+        self._proposals_chosen = 0
+        self.variance = variance if variance is not None else mx.nd.array([1.], dtype=self._dtype)
+        if proposal is None:
+            proposal = Posterior(model)
+            for rv in model.get_latent_variables(observed):
+                rv_copy = Variable()
+                self._map[rv.uuid] = rv_copy.uuid
+                proposal[rv].set_prior(Normal(mean=rv_copy, variance=self.variance))
+
+        super(MetropolisHastingsAlgorithm, self).__init__(
+            model=model, observed=observed, num_samples=num_samples,
+            target_variables=target_variables, extra_graphs=[proposal])
+
+    def compute(self, F, variables):
+        """
+        Returns Metropolis-Hastings samples.
+        :param x: {'uuid': latest sample}
+        :rtype: {'uuid': next sample}
+        """
+        x = variables.copy()
+        x = {k if k not in self._map else self._map[k] : v for k,v in x.items()}
+        # draw proposal samples using the last steps output
+        x_proposal = self.proposal.draw_samples(F, variables=x, num_samples=1)
+        x_proposal_full = x_proposal.copy()
+        # compute new ratio
+        x_proposal_full.update({k:v for k,v in x.items() if k not in x_proposal})
+        proposal_new = self.proposal.log_pdf(F, x_proposal_full)
+        proposal_old = self.proposal.log_pdf(F, variables)
+        model_new = self.model.log_pdf(F, x_proposal_full)
+        model_old = self.model.log_pdf(F, variables)
+        alpha = -(proposal_old + model_old - proposal_new - model_new)
+        r_min = F.minimum(mx.nd.array([0], dtype=self._dtype),alpha)
+
+        # TODO replace with our random generator
+        # u = F.log(self._rand_gen.uniform(0,1))
+        unif_sample = F.log(F.random.uniform(low=0, high=1, dtype=self._dtype))
+
+        # return this step's samples based on ratio
+        if unif_sample < r_min:
+            is_proposal = True
+            return_choice = x_proposal_full
+        else:
+            return_choice = variables
+            is_proposal = False
+        xp_keys = set(x_proposal.keys())
+        orig_keys = set(variables.keys())
+        return_subset = {k:v for k,v in return_choice.items() if k in x_proposal}
+        # print("Original : {} \n Proposal : {} \n : mu_copy {}\n".format(variables[self.proposal.mu.uuid].asnumpy(), x_proposal[self.proposal.mu.uuid].asnumpy(), variables[self.proposal.mu.factor.mean.uuid].asnumpy()))
+        # print("unif {} : r {} : alpha {}".format(unif_sample.asscalar(), r_min.asscalar(), alpha.asscalar()))
+        # print("q(old) {} + m(old) {} - p(new) - {} m(new) : {} \n".format(proposal_old.asscalar(), model_old.asscalar(), proposal_new.asscalar(), model_new.asscalar()))
+        return return_subset, is_proposal
+
+    @property
+    def proposal(self):
+        """
+        Return the proposal distribution
+        """
+        return self._extra_graphs[0]
+
+
+class MCMCInference(Inference):
+    """
+    The abstract class for MCMC-based inference methods.
+    An inference method consists of a few components: the applied inference algorithm, the model definition, and the inference parameters.
+
+    :param inference_algorithm: The applied inference algorithm
+    :type inference_algorithm: InferenceAlgorithm
+    :param graphs: a list of graph definitions required by the inference method. It includes the model definition and necessary posterior approximation.
+    :type graphs: [FactorGraph]
+    :param observed: A list of observed variables
+    :type observed: [Variable]
+    :param constants: Specify a list of model variables as constants
+    :type constants: {Variable: mxnet.ndarray}
+    :param hybridize: Whether to hybridize the MXNet Gluon block of the inference method.
+    :type hybridize: boolean
+    :param dtype: data type for internal numerical representation
+    :type dtype: {numpy.float64, numpy.float32, 'float64', 'float32'}
+    :param context: The MXNet context
+    :type context: {mxnet.cpu or mxnet.gpu}
+    """
+    def __init__(self, inference_algorithm, constants=None,
+                 hybridize=False, dtype=None, context=None):
+        super(MCMCInference, self).__init__(
+            inference_algorithm=inference_algorithm, constants=constants,
+            hybridize=hybridize, dtype=dtype, context=context)
+        self._number_proposals = 0
+        self.samples = {}
+
+    def create_executor(self):
+        """
+        Return a MXNet Gluon block responsible for the execution of the inference method.
+        """
+        infr = self._inference_algorithm.create_executor(
+            data_def=self.observed_variable_UUIDs, params=self.params,
+            var_ties=self.params.var_ties, rv_scaling=None)
+        if self._hybridize:
+            infr.hybridize()
+        infr.initialize(ctx=self.mxnet_context)
+        return infr
+
+    def run(self, optimizer='adam', learning_rate=1e-3, max_iter=2000,
+            verbose=False, n_prints=10, **kwargs):
+        """
+        Run the inference method.
+
+        :param optimizer: the choice of optimizer (default: 'adam')
+        :type optimizer: str
+        :param learning_rate: the learning rate of the gradient optimizer (default: 0.001)
+        :type learning_rate: float
+        :param max_iter: the maximum number of iterations of gradient optimization
+        :type max_iter: int
+        :param verbose: whether to print per-iteration messages.
+        :type verbose: boolean
+        :param **kwargs: The keyword arguments specify the data for inferences. The key of each argument is the name of the corresponding
+            variable in model definition and the value of the argument is the data in numpy array format.
+        """
+        data = [kwargs[v] for v in self.observed_variable_names]
+        self.initialize(**kwargs)
+
+        self.params._params.initialize(ctx=self.mxnet_context)
+        infr = self.create_executor()
+        iter_step = max(max_iter // n_prints, 1)
+        for i in range(max_iter):
+            sample, is_proposal = infr(mx.nd.zeros(1), *data)
+            if is_proposal:
+                self._number_proposals += 1
+            for k,v in sample.items():
+                if k not in self.samples:
+                    self.samples[k] = []
+                self.samples[k].append(v)
+                v_shaped = mx.nd.reshape(v, shape=self.params._params.get(k).data().shape)
+                self.params._params.get(k).set_data(v_shaped)
+                self.params._params.get(self.inference_algorithm._map[k]).set_data(v_shaped)
+            if verbose and i > 0 and i % iter_step == 0:
+                print("{}th step. Acceptance rate so far: {:2f}".format(i, (self._number_proposals) / i))
+
+        self.samples = {k: mx.nd.concat(*v, dim=0) for k,v in self.samples.items()}
+        return self.samples

--- a/mxfusion/models/factor_graph.py
+++ b/mxfusion/models/factor_graph.py
@@ -239,6 +239,7 @@ class FactorGraph(object):
         """
         Draw samples from the target variables of the Factor Graph. If the ``targets`` argument is None, draw samples from all the variables
         that are *not* in the conditional variables. If the ``targets`` argument is given, this method returns a list of samples of variables in the order of the target argument, otherwise it returns a dict of samples where the keys are the UUIDs of variables and the values are the samples.
+        Adds drawn samples directly into the variables argument.
 
         :param F: the MXNet computation mode (``mxnet.symbol`` or ``mxnet.ndarray``).
         :param variables: The set of variables
@@ -454,6 +455,17 @@ class FactorGraph(object):
         :rtype: [Variable]
         """
         return [v for v in self.variables.values() if v.type == VariableType.CONSTANT]
+
+    def get_latent_variables(self, observed):
+        """
+        Get the latent variables of the model.
+
+        :param observed: a list of observed variables.
+        :type observed: [UUID]
+        :returns: the list of latent variables.
+        :rtype: [Variable]
+        """
+        return [v for v in self.variables.values() if v.type == VariableType.RANDVAR and v.uuid not in observed]
 
 
     @staticmethod

--- a/mxfusion/models/model.py
+++ b/mxfusion/models/model.py
@@ -30,17 +30,6 @@ class Model(FactorGraph):
         """
         super(Model, self).__init__(name=name, verbose=verbose)
 
-    def get_latent_variables(self, observed):
-        """
-        Get the latent variables of the model.
-
-        :param observed: a list of observed variables.
-        :type observed: [UUID]
-        :returns: the list of latent variables.
-        :rtype: [Variable]
-        """
-        return [v for v in self.variables.values() if v.type == VariableType.RANDVAR and v.uuid not in observed]
-
     def _replicate_class(self, **kwargs):
         """
         Returns a new instance of the derived FactorGraph's class.

--- a/testing/inference/mhmc_sampling_test.py
+++ b/testing/inference/mhmc_sampling_test.py
@@ -1,0 +1,122 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License").
+#   You may not use this file except in compliance with the License.
+#   A copy of the License is located at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   or in the "license" file accompanying this file. This file is distributed
+#   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+#   express or implied. See the License for the specific language governing
+#   permissions and limitations under the License.
+# ==============================================================================
+
+
+import unittest
+import numpy as np
+import mxnet as mx
+import mxnet.gluon.nn as nn
+import mxfusion as mf
+from mxfusion.inference.mh_sampling import MCMCInference, MetropolisHastingsAlgorithm
+from mxfusion.components.functions import MXFusionGluonFunction
+from mxfusion.common.config import get_default_dtype
+from mxfusion.models import Model
+from mxfusion.components.distributions import Normal
+
+
+class MetropolisHastingsTests(unittest.TestCase):
+    """
+    Test class that tests the MetropolisHastings and MCMC methods.
+    """
+
+    def make_simple_model(self, N=100):
+        dtype = get_default_dtype()
+        m = Model()
+        m.mu = Normal.define_variable(mean=mx.nd.array([0], dtype=dtype),
+                                      variance=mx.nd.array([100], dtype=dtype), shape=(1,))
+
+        m.s_hat = Normal.define_variable(mean=mx.nd.array([5], dtype=dtype),
+                                         variance=mx.nd.array([100], dtype=dtype),
+                                         shape=(1,), dtype=dtype)
+        trans_mxnet = mx.gluon.nn.HybridLambda(lambda F, x: F.Activation(x, act_type='softrelu'))
+        m.trans = MXFusionGluonFunction(trans_mxnet, num_outputs=1, broadcastable=True)
+        m.s = m.trans(m.s_hat)
+        m.Y = Normal.define_variable(mean=m.mu, variance=m.s, shape=(N,), dtype=dtype)
+
+        return m
+
+    def generate_simple_data(self, N=100):
+        mean_groundtruth = 3.
+        variance_groundtruth = 5.
+        data = np.random.randn(N)*np.sqrt(variance_groundtruth) + mean_groundtruth
+        return data
+
+
+    def test_basic_mhmc_sampling(self):
+        dtype = get_default_dtype()
+        m = self.make_simple_model()
+        data = self.generate_simple_data()
+
+        observed = [m.Y]
+        alg = MetropolisHastingsAlgorithm(m, observed, dtype=dtype)
+        infr = MCMCInference(alg)
+        iterations = 30
+        samples = infr.run(Y=mx.nd.array(data, dtype=dtype), max_iter=iterations, verbose=True)
+
+        samples_mu = samples[infr.inference_algorithm.proposal.mu.uuid].asnumpy()[-1]
+        parameters_mu = infr.params[infr.inference_algorithm.proposal.mu].asnumpy()
+        parameters_mu_prev = infr.params[infr.inference_algorithm.proposal.mu.factor.mean].asnumpy()
+        # print("samples_mu : {} \n Proposal : {} \n : z_copy {}\n".format(samples_mu, parameters_mu, parameters_mu_prev))
+
+        self.assertTrue(parameters_mu == samples_mu)
+        self.assertTrue(parameters_mu == parameters_mu_prev)
+
+    def make_ppca_model(self, w, noise_var, N, K, D):
+        dtype = get_default_dtype()
+        from mxfusion.models import Model
+        import mxnet.gluon.nn as nn
+        from mxfusion.components import Variable
+        from mxfusion.components.variables import PositiveTransformation
+        m = Model()
+        m.w = Variable(shape=(K,D), value=mx.nd.array(w))
+        dot = nn.HybridLambda(function='dot')
+        m.dot = mf.functions.MXFusionGluonFunction(dot, num_outputs=1, broadcastable=False)
+        cov = mx.nd.broadcast_to(mx.nd.expand_dims(mx.nd.array(np.eye(K,K)), 0),shape=(N,K,K))
+        m.z = mf.distributions.MultivariateNormal.define_variable(mean=mx.nd.zeros(shape=(N,K)), covariance=cov, shape=(N,K))
+        sigma_2 = Variable(shape=(1,), value=mx.nd.array(noise_var))
+        m.x = mf.distributions.Normal.define_variable(mean=m.dot(m.z, m.w), variance=sigma_2, shape=(N,D))
+
+        return m
+
+    def generate_ppca_data(self, N, K, D):
+        def log_spiral(a,b,t):
+            x = a * np.exp(b*t) * np.cos(t)
+            y = a * np.exp(b*t) * np.sin(t)
+            return np.vstack([x,y]).T
+
+        a = 1
+        b = 0.1
+        t = np.linspace(0,6*np.pi,N)
+        r = log_spiral(a,b,t)
+        w = np.random.randn(K,N)
+        x_train = np.dot(r,w) + np.random.randn(N,N) * 1e-3
+        return x_train, w
+
+    def test_ppca_model_mhmc_sampling(self):
+        dtype = get_default_dtype()
+        N = 5
+        D = 5
+        K = 2
+        noise_var = mx.nd.array([1.])
+        x_train, w = self.generate_ppca_data(N, K, D)
+        m = self.make_ppca_model(w, noise_var, N, K, D)
+
+        observed = [m.x]
+        alg = MetropolisHastingsAlgorithm(m, observed, variance=mx.nd.array([1e-4]))
+        infr = MCMCInference(alg)
+        infr.initialize(x=mx.nd.array(x_train))
+        iterations = 1000
+        samples = infr.run(max_iter=iterations,  x=mx.nd.array(x_train), verbose=True)
+
+        samples_mu = samples[infr.inference_algorithm.proposal.z.uuid].asnumpy()


### PR DESCRIPTION
## Description of changes

This is a design proposal and code for adding an MCMC sampler to MXFusion. 

Right now the method just uses a Normal distribution as the proposal distribution, but it could be extended to take in other proposal distributions. Open to suggestions here, but also happy to merge this in for now as a first and improve the generality later on as needed (should be straightforward.)

## Testing
It successfully trained the Getting Started tutorial and the PPCA tutorial after adding a prior to ```m.w``` and using ```variance=1e-4``` for the proposal distributions.

Also wrote two basic 'run-through' tests for the code. It doesn't have any real correctness tests outside of the manual PPCA test that I ran to verify that it trained right. Would be open to adding one, but I'm not sure what that looks like in this case.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
