### PR TITLE
Changed transpose property to function. 

### DIFF
--- a/mxfusion/components/variables/variable.py
+++ b/mxfusion/components/variables/variable.py
@@ -263,14 +263,3 @@ class Variable(ModelComponent):
     def __pow__(self, y):
         from ..functions.operators import power
         return power(self, y)
-
-    def transpose(self):
-        """
-        Creates a variable that is the transpose of this variable.
-        Note that this variable will be attached to the graph as a descendant to self via the transpose operator.
-        Also note that [this replaces the .T property](https://github.com/amzn/MXFusion/pull/137#issue-233291080)
-
-        :return: the transposed variable
-        """
-        from ..functions.operators import transpose
-        return transpose(self)

--- a/mxfusion/components/variables/variable.py
+++ b/mxfusion/components/variables/variable.py
@@ -264,7 +264,6 @@ class Variable(ModelComponent):
         from ..functions.operators import power
         return power(self, y)
 
-    @property
-    def T(self):
+    def transpose(self):
         from ..functions.operators import transpose
         return transpose(self)

--- a/mxfusion/components/variables/variable.py
+++ b/mxfusion/components/variables/variable.py
@@ -265,5 +265,12 @@ class Variable(ModelComponent):
         return power(self, y)
 
     def transpose(self):
+        """
+        Creates a variable that is the transpose of this variable.
+        Note that this variable will be attached to the graph as a descendant to self via the transpose operator.
+        Also note that [this replaces the .T property](https://github.com/amzn/MXFusion/pull/137#issue-233291080)
+
+        :return: the transposed variable
+        """
         from ..functions.operators import transpose
         return transpose(self)

--- a/testing/components/functions/operators_test.py
+++ b/testing/components/functions/operators_test.py
@@ -93,7 +93,7 @@ class TestOperators(object):
         elif case == "pow":
             m2.r = v12 ** v22
         elif case == "transpose":
-            m2.r = v12.T
+            m2.r = v12.transpose()
         vs2 = [v for v in m2.r.factor.inputs]
         variables_rt2 = {v[1].uuid: inputs[i] for i,v in enumerate(vs2)}
         p_eval = m2.r.factor.eval(mx.nd, variables=variables_rt2)

--- a/testing/components/functions/operators_test.py
+++ b/testing/components/functions/operators_test.py
@@ -93,7 +93,7 @@ class TestOperators(object):
         elif case == "pow":
             m2.r = v12 ** v22
         elif case == "transpose":
-            m2.r = v12.transpose()
+            m2.r = transpose(v12)
         vs2 = [v for v in m2.r.factor.inputs]
         variables_rt2 = {v[1].uuid: inputs[i] for i,v in enumerate(vs2)}
         p_eval = m2.r.factor.eval(mx.nd, variables=variables_rt2)


### PR DESCRIPTION
This stops the debugger accidentally creating new variables on access.

*Description of changes:*
When using an interactive debugger (e.g. PyCharm), inspecting any `Variable` object invokes the property `T` which has the side effect of creating new variables that are not part of the graph. By changing this to a function `.transpose()` the functionality is maintained (at the slight expense of ease of use) whilst preventing this from happening.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
