### PR TITLE
Reduce num_samples in uniform non-mock test to 1000

### DIFF
--- a/testing/components/distributions/uniform_test.py
+++ b/testing/components/distributions/uniform_test.py
@@ -98,7 +98,7 @@ class TestUniformDistribution(object):
     def test_draw_samples_non_mock(self, plot=False):
         # Also make sure the non-mock sampler works
         dtype = np.float32
-        num_samples = 10000
+        num_samples = 1000
 
         low = np.array([0.5])
         high = np.array([2])


### PR DESCRIPTION
Reduce the number of samples we draw a fit a uniform distribution using from 10,000 to 1,000 in the non-mock uniform sampling test. When its set to 10,000 the test doesn't successfully run on my laptop and just hangs eternally. I tested it a bunch of times with this 1,000 samples and checked the numerical accuracy and it looked close enough that it shouldn't be a flaky test. 

If it ends up being an issue I'm in favor of removing the test or having a separate suite of "validity" tests, since I can't run the tests locally otherwise.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
