### PR TITLE
Move constants in InferenceParameters into ParameterDict

### DIFF
--- a/docs/design_documents/inference.md
+++ b/docs/design_documents/inference.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Inference in MXFusion is broken down into a few logical pieces that can be combined together as necessary.
+Inference in MXFusion is broken down into a few logical pieces that can be combined together as necessary. MXFusion relies on MXNet's Gluon as the underlying computational engine.
 
 The highest level object you'll deal with will be derived from the ```mxfusion.inference.Inference``` class. This is the outer loop that drives the inference algorithm, holds the relevant parameters and models for training, and handles serialization after training. At a minimum, ```Inference``` objects take as input the ```InferenceAlgorithm``` to run. On creation, an ```InferenceParameters``` object is created and attached to the ```Inference``` method which will store and manage (MXNet) parameters during inference.
 
@@ -126,3 +126,21 @@ infr2.load(primary_model_file=PREFIX+'_graph_0.json',
 
 
 ```
+
+## Inference Internals
+
+Inference in MXFusion happens in a few steps.
+
+The first thing for a variational inference method is to create a ```Posterior``` from the ```Model```, which makes a copy of the model that can then be changed without altering the structure of the original model while allowing the user to logically reference the same variable in the model and posterior.
+
+When the ```InferenceAlgorithm``` object is created, references to the ```Model``` and ```Posterior``` objects are kept but no additional MXNet memory or parameters are allocated at this time.
+
+When the ```Inference``` object is created, again, references to the graph objects are kept and an ```InferenceParameters``` object is created, but no MXNet memory is allocated yet.
+
+Some ```Inference``` classes need their ```initialize(...)``` methods be called before calling ```run(...)```, but most can be called by simply calling ```run(...)``` with the appropriate arguments, and it will call initialize before proceeding with the run step.
+
+When ```run(**kwargs)``` is called, the 3 primary steps happen:
+1. ```Inference.initialize()``` is called if not already initialized. This derives the correct shapes of everything from the data passed in via ```kwargs``` and initializes all of the MXNet Parameter objects needed for the computation.
+2. ```Inference.create_executor()``` is called (which calls it's ```InferenceAlgorithm.create_executor()```'s method) to create an ObjectiveBlock. This is an MXNet Gluon HybridBlock object. This is the primary computational graph object which gets executed to perform inference in MXFusion.
+ * If desired, this block can be hybridized and saved down into a symbolic graph for reloading by passing in ```hybridize=True``` when initializing your ```Inference``` object. See MXNet Gluon documentation on [hybrid mode](https://mxnet.incubator.apache.org/tutorials/gluon/hybrid.html) for more details.
+3. The ```ObjectiveBlock``` or ```executor``` created in the last step is now run, running data through the MXNet compute graph that was constructed.

--- a/docs/design_documents/inference.md
+++ b/docs/design_documents/inference.md
@@ -131,16 +131,15 @@ infr2.load(primary_model_file=PREFIX+'_graph_0.json',
 
 Inference in MXFusion happens in a few steps.
 
-The first thing for a variational inference method is to create a ```Posterior``` from the ```Model```, which makes a copy of the model that can then be changed without altering the structure of the original model while allowing the user to logically reference the same variable in the model and posterior.
+1. The first thing to use a variational inference method is to create a ```Posterior``` instance from the ```Model``` instace, which keeps a reference to the model, allowing the user to logically reference the same variable in the model and posterior.
 
-When the ```InferenceAlgorithm``` object is created, references to the ```Model``` and ```Posterior``` objects are kept but no additional MXNet memory or parameters are allocated at this time.
+2. When the ```InferenceAlgorithm``` object is created, the references to the ```Model``` and ```Posterior``` objects are kept, but no additional MXNet memory or parameters are allocated at this time.
 
-When the ```Inference``` object is created, again, references to the graph objects are kept and an ```InferenceParameters``` object is created, but no MXNet memory is allocated yet.
+3. When the ```Inference``` object is created, again, references to the inference algorithm is kept and internally an ```InferenceParameters``` object is created, but no MXNet memory is allocated yet.
 
-Some ```Inference``` classes need their ```initialize(...)``` methods be called before calling ```run(...)```, but most can be called by simply calling ```run(...)``` with the appropriate arguments, and it will call initialize before proceeding with the run step.
+4. (optional) The ```initialize(...)``` method of the ```Inference``` object triggers the allocation of MXNet memory on the specified hardware. Alternatively, one can directly call the ```run(...)``` method, which internally calls the ```initialize(...)``` method.
 
-When ```run(**kwargs)``` is called, the 3 primary steps happen:
-1. ```Inference.initialize()``` is called if not already initialized. This derives the correct shapes of everything from the data passed in via ```kwargs``` and initializes all of the MXNet Parameter objects needed for the computation.
+5. When ```run(**kwargs)``` is called, internally the 3 primary steps happen:
+    1. ```Inference.initialize()``` is called if not already initialized. This derives the correct shapes of everything from the data passed in via ```kwargs``` and initializes all of the MXNet Parameter objects needed for the computation.
 2. ```Inference.create_executor()``` is called (which calls it's ```InferenceAlgorithm.create_executor()```'s method) to create an ObjectiveBlock. This is an MXNet Gluon HybridBlock object. This is the primary computational graph object which gets executed to perform inference in MXFusion.
- * If desired, this block can be hybridized and saved down into a symbolic graph for reloading by passing in ```hybridize=True``` when initializing your ```Inference``` object. See MXNet Gluon documentation on [hybrid mode](https://mxnet.incubator.apache.org/tutorials/gluon/hybrid.html) for more details.
-3. The ```ObjectiveBlock``` or ```executor``` created in the last step is now run, running data through the MXNet compute graph that was constructed.
+    3. The ```ObjectiveBlock``` or ```executor``` created in the last step is now run, running data through the MXNet compute graph that was constructed.

--- a/mxfusion/inference/inference_alg.py
+++ b/mxfusion/inference/inference_alg.py
@@ -16,6 +16,7 @@
 from abc import ABC, abstractmethod
 from mxnet.gluon import HybridBlock
 from mxnet import autograd
+import mxnet as mx
 from ..common.constants import SET_PARAMETER_PREFIX
 from ..components.variables import VariableType
 from ..components.variables import add_sample_dimension_to_arrays
@@ -78,7 +79,7 @@ class ObjectiveBlock(HybridBlock):
         for k, v in self._var_trans.items():
             kw[k] = v.transform(kw[k], F=F)
         add_sample_dimension_to_arrays(F, kw, out=variables)
-        add_sample_dimension_to_arrays(F, self._constants, out=variables)
+        variables.update(self._constants)
         obj = self._infr_method.compute(F=F, variables=variables)
         with autograd.pause():
             # An inference algorithm may directly set the value of a parameter instead of computing its gradient.
@@ -189,7 +190,7 @@ class InferenceAlgorithm(ABC):
         """
         Create a MXNet Gluon block to carry out the computation.
 
-        :param data_def: a list of unique ID of data variables. The order of
+        :param data_def: a list of unique IDs of data variables. The order of
             variables in the list corresponds to the order of variable in the
             positional arguments when calling the Gluon Block.
         :type data_def: [UUID of Variable (str)]
@@ -207,8 +208,10 @@ class InferenceAlgorithm(ABC):
             var_trans_m, excluded_m = m.prepare_executor(rv_scaling=rv_scaling)
             var_trans.update(var_trans_m)
             excluded = excluded.union(excluded_m)
+
+        non_mxnet_constants = {k:v for k,v in params.constants.items() if not isinstance(v, mx.ndarray.ndarray.NDArray)}
         block = ObjectiveBlock(infr_method=self, params=params,
-                               constants=params.constants,
+                               constants=non_mxnet_constants,
                                data_def=data_def, var_trans=var_trans,
                                var_ties=var_ties, excluded=excluded)
         return block

--- a/mxfusion/inference/inference_parameters.py
+++ b/mxfusion/inference/inference_parameters.py
@@ -103,6 +103,8 @@ class InferenceParameters(object):
         for uuid, constant in self._constants.items():
             if isinstance(constant, mx.ndarray.ndarray.NDArray):
                 self._params.get_constant(uuid, constant)
+        self._constants = {k:v for k,v in self._constants.items()
+                           if not isinstance(v, mx.ndarray.ndarray.NDArray)}
 
         self._params.initialize(ctx=self.mxnet_context)
 
@@ -151,7 +153,10 @@ class InferenceParameters(object):
 
     @property
     def constants(self):
-        return self._constants
+
+        consts = {k:p.data() for k,p in self._params.items() if isinstance(p, mx.gluon.parameter.Constant)}
+        consts.update(self._constants)
+        return consts
 
     @property
     def var_ties(self):

--- a/testing/inference/inference_parameters_test.py
+++ b/testing/inference/inference_parameters_test.py
@@ -30,13 +30,12 @@ class InferenceParametersTests(unittest.TestCase):
             os.remove(filename)
 
     def test_save_reload_constants(self):
-        constants = {Variable(): 5, 'uuid': mx.nd.array([1])}
+        constants = {Variable(): 5}
         ip = InferenceParameters(constants=constants)
         ip.save(prefix="constants_test")
         # assert the file is there
 
         ip2 = InferenceParameters.load_parameters(
-            mxnet_constants_file='constants_test_mxnet_constants.json',
             variable_constants_file='constants_test_variable_constants.json')
         print(ip.constants)
         print(ip2.constants)


### PR DESCRIPTION
*Description of changes:*
Shift MXNet based constants from being stored in the InferenceParameters._constants dictionary (which still exists and keeps scalar/native constants) to keeping MXNet constants in the ParameterDict where other Parameters are kept.

This removes the need for the separate MXNet constants file at serialization file as well!

(Feel free to ignore the documentation change here, it's a remnant of the larger docs change I made in another PR and I'll try to make sure the other one is the one that gets kept.)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
