### PR TITLE
Fix a bug for SVGP regression with minibatch traning

### DIFF
--- a/mxfusion/components/distributions/gp/kernels/__init__.py
+++ b/mxfusion/components/distributions/gp/kernels/__init__.py
@@ -24,14 +24,17 @@ Submodules
     add_kernel
     kernel
     linear
+    matern
     rbf
     static
     stationary
 """
 
-__all__ = ['add_kernel', 'kernel', 'linear', 'rbf', 'static', 'stationary']
+__all__ = ['add_kernel', 'kernel', 'linear',  'matern', 'rbf', 'static',
+           'stationary']
 
 from .add_kernel import AddKernel
 from .rbf import RBF
 from .linear import Linear
 from .static import Bias, White
+from .matern import Matern52, Matern32, Matern12

--- a/mxfusion/components/distributions/gp/kernels/matern.py
+++ b/mxfusion/components/distributions/gp/kernels/matern.py
@@ -1,0 +1,150 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License").
+#   You may not use this file except in compliance with the License.
+#   A copy of the License is located at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   or in the "license" file accompanying this file. This file is distributed
+#   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+#   express or implied. See the License for the specific language governing
+#   permissions and limitations under the License.
+# ==============================================================================
+
+
+import numpy as np
+import mxnet as mx
+from .stationary import StationaryKernel
+
+
+class Matern(StationaryKernel):
+    """
+    Matern kernel:
+
+    .. math::
+       k(r^2) = \\sigma^2 \\exp \\bigg(- \\frac{1}{2} r^2 \\bigg)
+
+    :param input_dim: the number of dimensions of the kernel. (The total number of active dimensions)
+    :type input_dim: int
+    :param ARD: a binary switch for Automatic Relevance Determination (ARD). If true, the squared distance is divided by a lengthscale for individual
+        dimensions.
+    :type ARD: boolean
+    :param variance: the initial value for the variance parameter (scalar), which scales the whole covariance matrix.
+    :type variance: float or MXNet NDArray
+    :param lengthscale: the initial value for the lengthscale parameter.
+    :type lengthscale: float or MXNet NDArray
+    :param name: the name of the kernel. The name is used to access kernel parameters.
+    :type name: str
+    :param active_dims: The dimensions of the inputs that are taken for the covariance matrix computation. (default: None, taking all the dimensions).
+    :type active_dims: [int] or None
+    :param dtype: the data type for float point numbers.
+    :type dtype: numpy.float32 or numpy.float64
+    :param ctx: the mxnet context (default: None/current context).
+    :type ctx: None or mxnet.cpu or mxnet.gpu
+    """
+    broadcastable = True
+
+    def __init__(self, input_dim, order, ARD=False, variance=1.,
+                 lengthscale=1., name='matern', active_dims=None, dtype=None,
+                 ctx=None):
+        super(Matern, self).__init__(
+            input_dim=input_dim, ARD=ARD, variance=variance,
+            lengthscale=lengthscale, name=name, active_dims=active_dims,
+            dtype=dtype, ctx=ctx)
+        self.order = order
+
+
+class Matern52(Matern):
+    def __init__(self, input_dim, ARD=False, variance=1., lengthscale=1.,
+                 name='matern52', active_dims=None, dtype=None, ctx=None):
+        super(Matern52, self).__init__(
+            input_dim=input_dim, order=2, ARD=ARD, variance=variance,
+            lengthscale=lengthscale, name=name, active_dims=active_dims,
+            dtype=dtype, ctx=ctx)
+
+    def _compute_K(self, F, X, lengthscale, variance, X2=None):
+        """
+        The internal interface for the actual covariance matrix computation.
+
+        :param F: MXNet computation type <mx.sym, mx.nd>.
+        :param X: the first set of inputs to the kernel.
+        :type X: MXNet NDArray or MXNet Symbol
+        :param X2: (optional) the second set of arguments to the kernel. If X2 is None, this computes a square covariance matrix of X. In other words,
+            X2 is internally treated as X.
+        :type X2: MXNet NDArray or MXNet Symbol
+        :param variance: the variance parameter (scalar), which scales the whole covariance matrix.
+        :type variance: MXNet NDArray or MXNet Symbol
+        :param lengthscale: the lengthscale parameter.
+        :type lengthscale: MXNet NDArray or MXNet Symbol
+        :return: The covariance matrix.
+        :rtype: MXNet NDArray or MXNet Symbol
+        """
+        R2 = self._compute_R2(F, X, lengthscale, variance, X2=X2)
+        R = F.sqrt(F.clip(R2, 1e-14, np.inf))
+        return F.broadcast_mul(
+            (1+np.sqrt(5)*R+5/3.*R2)*F.exp(-np.sqrt(5)*R),
+            F.expand_dims(variance, axis=-2))
+
+
+class Matern32(Matern):
+    def __init__(self, input_dim, ARD=False, variance=1., lengthscale=1.,
+                 name='matern32', active_dims=None, dtype=None, ctx=None):
+        super(Matern32, self).__init__(
+            input_dim=input_dim, order=1, ARD=ARD, variance=variance,
+            lengthscale=lengthscale, name=name, active_dims=active_dims,
+            dtype=dtype, ctx=ctx)
+
+    def _compute_K(self, F, X, lengthscale, variance, X2=None):
+        """
+        The internal interface for the actual covariance matrix computation.
+
+        :param F: MXNet computation type <mx.sym, mx.nd>.
+        :param X: the first set of inputs to the kernel.
+        :type X: MXNet NDArray or MXNet Symbol
+        :param X2: (optional) the second set of arguments to the kernel. If X2 is None, this computes a square covariance matrix of X. In other words,
+            X2 is internally treated as X.
+        :type X2: MXNet NDArray or MXNet Symbol
+        :param variance: the variance parameter (scalar), which scales the whole covariance matrix.
+        :type variance: MXNet NDArray or MXNet Symbol
+        :param lengthscale: the lengthscale parameter.
+        :type lengthscale: MXNet NDArray or MXNet Symbol
+        :return: The covariance matrix.
+        :rtype: MXNet NDArray or MXNet Symbol
+        """
+        R2 = self._compute_R2(F, X, lengthscale, variance, X2=X2)
+        R = F.sqrt(F.clip(R2, 1e-14, np.inf))
+        return F.broadcast_mul(
+            (1+np.sqrt(3)*R)*F.exp(-np.sqrt(3)*R),
+            F.expand_dims(variance, axis=-2))
+
+
+class Matern12(Matern):
+    def __init__(self, input_dim, ARD=False, variance=1., lengthscale=1.,
+                 name='matern12', active_dims=None, dtype=None, ctx=None):
+        super(Matern12, self).__init__(
+            input_dim=input_dim, order=0, ARD=ARD, variance=variance,
+            lengthscale=lengthscale, name=name, active_dims=active_dims,
+            dtype=dtype, ctx=ctx)
+
+    def _compute_K(self, F, X, lengthscale, variance, X2=None):
+        """
+        The internal interface for the actual covariance matrix computation.
+
+        :param F: MXNet computation type <mx.sym, mx.nd>.
+        :param X: the first set of inputs to the kernel.
+        :type X: MXNet NDArray or MXNet Symbol
+        :param X2: (optional) the second set of arguments to the kernel. If X2 is None, this computes a square covariance matrix of X. In other words,
+            X2 is internally treated as X.
+        :type X2: MXNet NDArray or MXNet Symbol
+        :param variance: the variance parameter (scalar), which scales the whole covariance matrix.
+        :type variance: MXNet NDArray or MXNet Symbol
+        :param lengthscale: the lengthscale parameter.
+        :type lengthscale: MXNet NDArray or MXNet Symbol
+        :return: The covariance matrix.
+        :rtype: MXNet NDArray or MXNet Symbol
+        """
+        R = F.sqrt(F.clip(self._compute_R2(F, X, lengthscale, variance, X2=X2),
+                          1e-14, np.inf))
+        return F.broadcast_mul(
+            F.exp(-np.sqrt(3)*R), F.expand_dims(variance, axis=-2))

--- a/mxfusion/components/distributions/gp/kernels/matern.py
+++ b/mxfusion/components/distributions/gp/kernels/matern.py
@@ -147,4 +147,4 @@ class Matern12(Matern):
         R = F.sqrt(F.clip(self._compute_R2(F, X, lengthscale, variance, X2=X2),
                           1e-14, np.inf))
         return F.broadcast_mul(
-            F.exp(-np.sqrt(3)*R), F.expand_dims(variance, axis=-2))
+            F.exp(-R), F.expand_dims(variance, axis=-2))

--- a/mxfusion/components/distributions/gp/kernels/rbf.py
+++ b/mxfusion/components/distributions/gp/kernels/rbf.py
@@ -14,7 +14,6 @@
 
 
 from .stationary import StationaryKernel
-from .....util.customop import broadcast_to_w_samples
 
 
 class RBF(StationaryKernel):
@@ -69,4 +68,4 @@ class RBF(StationaryKernel):
         :rtype: MXNet NDArray or MXNet Symbol
         """
         R2 = self._compute_R2(F, X, lengthscale, variance, X2=X2)
-        return F.exp(R2 / -2) * broadcast_to_w_samples(F, variance, R2.shape)
+        return F.exp(R2 / -2) * F.expand_dims(variance, axis=-1)

--- a/mxfusion/inference/minibatch_loop.py
+++ b/mxfusion/inference/minibatch_loop.py
@@ -79,11 +79,11 @@ class MinibatchInferenceLoop(GradLoop):
                     loss_for_gradient.backward()
                 if verbose:
                     print('\repoch {} Iteration {} loss: {}\t\t\t'.format(
-                          e + 1, i + 1, loss.asscalar() / self.batch_size),
+                          e + 1, i + 1, loss.asscalar()),
                           end='')
                 trainer.step(batch_size=self.batch_size,
                              ignore_stale_grad=True)
-                L_e += loss.asscalar() / self.batch_size
+                L_e += loss.asscalar()
                 n_batches += 1
             if verbose:
                 print('epoch-loss: {} '.format(L_e / n_batches))

--- a/mxfusion/modules/gp_modules/gp_regression.py
+++ b/mxfusion/modules/gp_modules/gp_regression.py
@@ -33,6 +33,12 @@ class GPRegressionLogPdf(VariationalInference):
     The method to compute the logarithm of the probability density function of
     a Gaussian process model with Gaussian likelihood.
     """
+    def __init__(self, model, posterior, observed, jitter=0.):
+        super(GPRegressionLogPdf, self).__init__(
+            model=model, posterior=posterior, observed=observed)
+        self.log_pdf_scaling = 1
+        self.jitter = jitter
+
     def compute(self, F, variables):
         X = variables[self.model.X]
         Y = variables[self.model.Y]
@@ -48,6 +54,9 @@ class GPRegressionLogPdf(VariationalInference):
         K = kern.K(F, X, **kern_params) + \
             F.expand_dims(F.eye(N, dtype=X.dtype), axis=0) * \
             F.expand_dims(noise_var, axis=-2)
+        if self.jitter > 0.:
+            K = K + F.expand_dims(F.eye(N, dtype=X.dtype), axis=0) * \
+                self.jitter
         L = F.linalg.potrf(K)
 
         if self.model.mean_func is not None:

--- a/mxfusion/modules/gp_modules/sparsegp_regression.py
+++ b/mxfusion/modules/gp_modules/sparsegp_regression.py
@@ -36,6 +36,7 @@ class SparseGPRegressionLogPdf(VariationalInference):
     def __init__(self, model, posterior, observed, jitter=0.):
         super(SparseGPRegressionLogPdf, self).__init__(
             model=model, posterior=posterior, observed=observed)
+        self.log_pdf_scaling = 1
         self.jitter = jitter
 
     def compute(self, F, variables):
@@ -245,14 +246,14 @@ class SparseGPRegression(Module):
     """
 
     def __init__(self, X, kernel, noise_var, inducing_inputs=None,
-                 inducing_num=10, mean_func=None,
+                 num_inducing=10, mean_func=None,
                  rand_gen=None, dtype=None, ctx=None):
         if not isinstance(X, Variable):
             X = Variable(value=X)
         if not isinstance(noise_var, Variable):
             noise_var = Variable(value=noise_var)
         if inducing_inputs is None:
-            inducing_inputs = Variable(shape=(inducing_num, kernel.input_dim))
+            inducing_inputs = Variable(shape=(num_inducing, kernel.input_dim))
         inputs = [('X', X), ('inducing_inputs', inducing_inputs),
                   ('noise_var', noise_var)]
         input_names = [k for k, _ in inputs]
@@ -341,7 +342,7 @@ class SparseGPRegression(Module):
 
     @staticmethod
     def define_variable(X, kernel, noise_var, shape=None, inducing_inputs=None,
-                        inducing_num=10, mean_func=None, rand_gen=None,
+                        num_inducing=10, mean_func=None, rand_gen=None,
                         dtype=None, ctx=None):
         """
         Creates and returns a variable drawn from a sparse Gaussian process regression.
@@ -370,7 +371,7 @@ class SparseGPRegression(Module):
         """
         gp = SparseGPRegression(
             X=X, kernel=kernel, noise_var=noise_var,
-            inducing_inputs=inducing_inputs, inducing_num=inducing_num,
+            inducing_inputs=inducing_inputs, num_inducing=num_inducing,
             mean_func=mean_func, rand_gen=rand_gen, dtype=dtype, ctx=ctx)
         gp._generate_outputs({'random_variable': shape})
         return gp.random_variable

--- a/mxfusion/modules/gp_modules/svgp_regression.py
+++ b/mxfusion/modules/gp_modules/svgp_regression.py
@@ -95,7 +95,7 @@ class SVGPRegressionLogPdf(VariationalInference):
         logL = logL + F.sum(F.sum(F.square(LinvKuf)/noise_var_m, axis=-1),
                             axis=-1)*D/2.
         logL = logL + F.sum(F.sum(Linvmu*LinvKufY, axis=-1), axis=-1)
-        logL = logL + self.model.U.factor.log_pdf_scaling*KL_u
+        logL = self.log_pdf_scaling*logL + KL_u
         return logL
 
 
@@ -265,14 +265,14 @@ class SVGPRegression(Module):
     """
 
     def __init__(self, X, kernel, noise_var, inducing_inputs=None,
-                 inducing_num=10, mean_func=None,
+                 num_inducing=10, mean_func=None,
                  rand_gen=None, dtype=None, ctx=None):
         if not isinstance(X, Variable):
             X = Variable(value=X)
         if not isinstance(noise_var, Variable):
             noise_var = Variable(value=noise_var)
         if inducing_inputs is None:
-            inducing_inputs = Variable(shape=(inducing_num, kernel.input_dim))
+            inducing_inputs = Variable(shape=(num_inducing, kernel.input_dim))
         inputs = [('X', X), ('inducing_inputs', inducing_inputs),
                   ('noise_var', noise_var)]
         input_names = [k for k, _ in inputs]
@@ -357,7 +357,7 @@ class SVGPRegression(Module):
 
     @staticmethod
     def define_variable(X, kernel, noise_var, shape=None, inducing_inputs=None,
-                        inducing_num=10, mean_func=None, rand_gen=None,
+                        num_inducing=10, mean_func=None, rand_gen=None,
                         dtype=None, ctx=None):
         """
         Creates and returns a variable drawn from a Stochastic variational sparse Gaussian process regression with Gaussian likelihood.
@@ -386,7 +386,7 @@ class SVGPRegression(Module):
         """
         gp = SVGPRegression(
             X=X, kernel=kernel, noise_var=noise_var,
-            inducing_inputs=inducing_inputs, inducing_num=inducing_num,
+            inducing_inputs=inducing_inputs, num_inducing=num_inducing,
             mean_func=mean_func, rand_gen=rand_gen, dtype=dtype, ctx=ctx)
         gp._generate_outputs({'random_variable': shape})
         return gp.random_variable

--- a/mxfusion/modules/module.py
+++ b/mxfusion/modules/module.py
@@ -64,6 +64,7 @@ class Module(Factor):
         self._log_pdf_algorithms = {}
         self._draw_samples_algorithms = {}
         self._prediction_algorithms = {}
+        self.log_pdf_scaling = 1
 
     def __contains__(self, key):
         return any([key in g for g in [self._module_graph] + self._extra_graphs])
@@ -307,6 +308,7 @@ class Module(Factor):
         :rtype: mxnet NDArray or mxnet Symbol
         """
         alg = self._get_algorithm_for_target_conditional_pair(self._log_pdf_algorithms, targets, variables, exact_match=True)
+        alg.log_pdf_scaling = self.log_pdf_scaling
         result = alg.compute(F, variables)
         return result
 
@@ -428,6 +430,7 @@ class Module(Factor):
         replicant.dtype = self.dtype
         replicant.ctx = self.ctx
         replicant._module_graph = self._module_graph.clone()
+        replicant.log_pdf_scaling = 1
 
         # Note this assumes the extra graphs are A) posteriors and B) derived from self._module_graph.
         replicant._extra_graphs = [m.clone(self._module_graph) for m in

--- a/testing/components/distributions/gp/kernel_test.py
+++ b/testing/components/distributions/gp/kernel_test.py
@@ -18,7 +18,7 @@ import mxnet as mx
 import numpy as np
 from mxfusion.components.variables import Variable
 from mxfusion.components.variables.runtime_variable import add_sample_dimension, array_has_samples, get_num_samples
-from mxfusion.components.distributions.gp.kernels import RBF, Linear, Bias, White
+from mxfusion.components.distributions.gp.kernels import RBF, Linear, Bias, White, Matern52, Matern32, Matern12
 from mxfusion.util.testutils import numpy_array_reshape, prepare_mxnet_array
 
 # These test cases depends on GPy. Put them  in try/except.
@@ -298,6 +298,75 @@ try:
             gpy_comb_kernel_test(X, X_isSamples, X2, X2_isSamples, kernel_params,
                                  num_samples, dtype, create_rbf_plus_linear,
                                  create_gpy_rbf_plus_linear)
+
+        @pytest.mark.parametrize("dtype, X, X_isSamples, X2, X2_isSamples, lengthscale, lengthscale_isSamples, variance, variance_isSamples, num_samples, input_dim, ARD", [
+            (np.float64, np.random.rand(5,2), False, np.random.rand(4,2), False, np.random.rand(2)+1e-4, False, np.random.rand(1)+1e-4, False, 1, 2, True),
+            (np.float64, np.random.rand(5,2), False, np.random.rand(4,2), False, np.random.rand(3,2)+1e-4, True, np.random.rand(1)+1e-4, False, 3, 2, True),
+            (np.float64, np.random.rand(5,2), False, np.random.rand(4,2), False, np.random.rand(2)+1e-4, False, np.random.rand(3,1)+1e-4, True, 3, 2, True),
+            (np.float64, np.random.rand(3,5,2), True, np.random.rand(3,4,2), True, np.random.rand(2)+1e-4, False, np.random.rand(1)+1e-4, False, 3, 2, True),
+            (np.float64, np.random.rand(3,5,2), True, np.random.rand(3,4,2), True, np.random.rand(1)+1e-4, False, np.random.rand(1)+1e-4, False, 3, 2, False),
+            ])
+        def test_Matern52_kernel(self, dtype, X, X_isSamples, X2, X2_isSamples,
+                            lengthscale, lengthscale_isSamples, variance,
+                            variance_isSamples, num_samples, input_dim, ARD):
+            def create_kernel():
+                return Matern52(input_dim, ARD, 1., 1., 'rbf', None, dtype)
+
+            def create_gpy_kernel():
+                return GPy.kern.Matern52(input_dim=input_dim, ARD=ARD)
+
+            kernel_params = {'lengthscale': (lengthscale, lengthscale_isSamples),
+                             'variance': (variance, variance_isSamples)}
+
+            gpy_kernel_test(X, X_isSamples, X2, X2_isSamples, kernel_params,
+                            num_samples, dtype, create_kernel,
+                            create_gpy_kernel)
+
+        @pytest.mark.parametrize("dtype, X, X_isSamples, X2, X2_isSamples, lengthscale, lengthscale_isSamples, variance, variance_isSamples, num_samples, input_dim, ARD", [
+            (np.float64, np.random.rand(5,2), False, np.random.rand(4,2), False, np.random.rand(2)+1e-4, False, np.random.rand(1)+1e-4, False, 1, 2, True),
+            (np.float64, np.random.rand(5,2), False, np.random.rand(4,2), False, np.random.rand(3,2)+1e-4, True, np.random.rand(1)+1e-4, False, 3, 2, True),
+            (np.float64, np.random.rand(5,2), False, np.random.rand(4,2), False, np.random.rand(2)+1e-4, False, np.random.rand(3,1)+1e-4, True, 3, 2, True),
+            (np.float64, np.random.rand(3,5,2), True, np.random.rand(3,4,2), True, np.random.rand(2)+1e-4, False, np.random.rand(1)+1e-4, False, 3, 2, True),
+            (np.float64, np.random.rand(3,5,2), True, np.random.rand(3,4,2), True, np.random.rand(1)+1e-4, False, np.random.rand(1)+1e-4, False, 3, 2, False),
+            ])
+        def test_Matern32_kernel(self, dtype, X, X_isSamples, X2, X2_isSamples,
+                            lengthscale, lengthscale_isSamples, variance,
+                            variance_isSamples, num_samples, input_dim, ARD):
+            def create_kernel():
+                return Matern32(input_dim, ARD, 1., 1., 'rbf', None, dtype)
+
+            def create_gpy_kernel():
+                return GPy.kern.Matern32(input_dim=input_dim, ARD=ARD)
+
+            kernel_params = {'lengthscale': (lengthscale, lengthscale_isSamples),
+                             'variance': (variance, variance_isSamples)}
+
+            gpy_kernel_test(X, X_isSamples, X2, X2_isSamples, kernel_params,
+                            num_samples, dtype, create_kernel,
+                            create_gpy_kernel)
+
+        @pytest.mark.parametrize("dtype, X, X_isSamples, X2, X2_isSamples, lengthscale, lengthscale_isSamples, variance, variance_isSamples, num_samples, input_dim, ARD", [
+            (np.float64, np.random.rand(5,2), False, np.random.rand(4,2), False, np.random.rand(2)+1e-4, False, np.random.rand(1)+1e-4, False, 1, 2, True),
+            (np.float64, np.random.rand(5,2), False, np.random.rand(4,2), False, np.random.rand(3,2)+1e-4, True, np.random.rand(1)+1e-4, False, 3, 2, True),
+            (np.float64, np.random.rand(5,2), False, np.random.rand(4,2), False, np.random.rand(2)+1e-4, False, np.random.rand(3,1)+1e-4, True, 3, 2, True),
+            (np.float64, np.random.rand(3,5,2), True, np.random.rand(3,4,2), True, np.random.rand(2)+1e-4, False, np.random.rand(1)+1e-4, False, 3, 2, True),
+            (np.float64, np.random.rand(3,5,2), True, np.random.rand(3,4,2), True, np.random.rand(1)+1e-4, False, np.random.rand(1)+1e-4, False, 3, 2, False),
+            ])
+        def test_Matern12_kernel(self, dtype, X, X_isSamples, X2, X2_isSamples,
+                            lengthscale, lengthscale_isSamples, variance,
+                            variance_isSamples, num_samples, input_dim, ARD):
+            def create_kernel():
+                return Matern12(input_dim, ARD, 1., 1., 'rbf', None, dtype)
+
+            def create_gpy_kernel():
+                return GPy.kern.OU(input_dim=input_dim, ARD=ARD)
+
+            kernel_params = {'lengthscale': (lengthscale, lengthscale_isSamples),
+                             'variance': (variance, variance_isSamples)}
+
+            gpy_kernel_test(X, X_isSamples, X2, X2_isSamples, kernel_params,
+                            num_samples, dtype, create_kernel,
+                            create_gpy_kernel)
 
 except ImportError:
     pass


### PR DESCRIPTION
- Fix a bug for SVGP regression with minibatch traning
- Implement Matern kernel family
- Remove broadcast_w_samples in stationary, rbf and linear kernel implementation for efficiency.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
