### PR TITLE
Fix docstring

### DIFF
--- a/mxfusion/inference/inference.py
+++ b/mxfusion/inference/inference.py
@@ -184,19 +184,18 @@ class Inference(object):
         :param graphs_file: The file containing the graphs to load back for this inference algorithm. The first of these is the primary graph.
         :type graphs_file: str of filename
         :param inference_configuration_file: The file containing any inference specific configuration needed to
-        reload this inference algorithm.
-            e.g. observation patterns used to train it.
+            reload this inference algorithm. e.g. observation patterns used to train it.
         :type inference_configuration_file: str of filename
         :param parameters_file: These are the parameters of the previous inference algorithm.
-        These are in a {uuid: mx.nd.array} mapping.
+            These are in a {uuid: mx.nd.array} mapping.
         :type mxnet_constants_file: file saved down with mx.nd.save(), so a {uuid: mx.nd.array} mapping saved
-        in a binary format.
+            in a binary format.
         :param mxnet_constants_file: These are the constants in mxnet format from the previous inference algorithm.
-        These are in a {uuid: mx.nd.array} mapping.
+            These are in a {uuid: mx.nd.array} mapping.
         :type mxnet_constants_file: file saved down with mx.nd.save(), so a {uuid: mx.nd.array} mapping saved
-        in a binary format.
+            in a binary format.
         :param variable_constants_file: These are the constants in primitive format from the previous
-        inference algorithm.
+            inference algorithm.
         :type variable_constants_file: json dict of {uuid: constant_primitive}
         """
         graphs = FactorGraph.load_graphs(graphs_file)


### PR DESCRIPTION
*Issue #, if available:* The [docs](https://mxfusion.readthedocs.io/en/master/generated/_autosummary/_autosummary/mxfusion.inference.inference.html?highlight=save#mxfusion.inference.inference.Inference.load ) for the load method were all mangled together:

*Description of changes:* Added some whites pace so the docs display properly


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
