### PR TITLE
Move the parameters of Gluon block to be controlled by MXFusion.

### DIFF
--- a/examples/notebooks/variational_auto_encoder.ipynb
+++ b/examples/notebooks/variational_auto_encoder.ipynb
@@ -6,28 +6,7 @@
    "source": [
     "# Variational Auto-Encoder (VAE)\n",
     "\n",
-    "### Zhenwen Dai (2018-8-21)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```\n",
-    "# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.\n",
-    "#\n",
-    "#   Licensed under the Apache License, Version 2.0 (the \"License\").\n",
-    "#   You may not use this file except in compliance with the License.\n",
-    "#   A copy of the License is located at\n",
-    "#\n",
-    "#       http://www.apache.org/licenses/LICENSE-2.0\n",
-    "#\n",
-    "#   or in the \"license\" file accompanying this file. This file is distributed\n",
-    "#   on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either\n",
-    "#   express or implied. See the License for the specific language governing\n",
-    "#   permissions and limitations under the License.\n",
-    "# ==============================================================================\n",
-    "```"
+    "### Zhenwen Dai (2019-04-23)"
    ]
   },
   {
@@ -101,11 +80,10 @@
     "H = 50\n",
     "encoder = nn.HybridSequential(prefix='encoder_')\n",
     "with encoder.name_scope():\n",
-    "    encoder.add(nn.Dense(H, activation=\"tanh\"))\n",
-    "    encoder.add(nn.Dense(H, activation=\"tanh\"))\n",
-    "    encoder.add(nn.Dense(Q, flatten=True))\n",
-    "encoder.initialize(mx.init.Xavier(magnitude=3))\n",
-    "_=encoder(mx.nd.array(np.random.rand(5,D)))"
+    "    encoder.add(nn.Dense(H, in_units=D, activation=\"tanh\", flatten=False))\n",
+    "    encoder.add(nn.Dense(H, in_units=H, activation=\"tanh\", flatten=False))\n",
+    "    encoder.add(nn.Dense(Q, in_units=H, flatten=False))\n",
+    "encoder.initialize(mx.init.Xavier(magnitude=3))"
    ]
   },
   {
@@ -117,11 +95,10 @@
     "H = 50\n",
     "decoder = nn.HybridSequential(prefix='decoder_')\n",
     "with decoder.name_scope():\n",
-    "    decoder.add(nn.Dense(H, activation=\"tanh\"))\n",
-    "    decoder.add(nn.Dense(H, activation=\"tanh\"))\n",
-    "    decoder.add(nn.Dense(D, flatten=True))\n",
-    "decoder.initialize(mx.init.Xavier(magnitude=3))\n",
-    "_=decoder(mx.nd.array(np.random.rand(5,Q)))"
+    "    decoder.add(nn.Dense(H, in_units=Q, activation=\"tanh\", flatten=False))\n",
+    "    decoder.add(nn.Dense(H, in_units=H, activation=\"tanh\", flatten=False))\n",
+    "    decoder.add(nn.Dense(D, in_units=H, flatten=False))\n",
+    "decoder.initialize(mx.init.Xavier(magnitude=3))"
    ]
   },
   {
@@ -130,7 +107,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from mxfusion.components.variables.var_trans import PositiveTransformation"
+    "from mxfusion.components.variables.var_trans import PositiveTransformation\n",
+    "from mxfusion import Variable, Model, Posterior\n",
+    "from mxfusion.components.functions import MXFusionGluonFunction\n",
+    "from mxfusion.components.distributions import Normal\n",
+    "from mxfusion.components.functions.operators import broadcast_to"
    ]
   },
   {
@@ -142,20 +123,26 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "x ~ Normal(mean=Variable(e909c), variance=Variable(e90bf))\n",
-      "f = GluonFunctionEvaluation(decoder_input_0=x, decoder_dense0_weight=Variable(0f71b), decoder_dense0_bias=Variable(aee54), decoder_dense1_weight=Variable(8db61), decoder_dense1_bias=Variable(7c56e), decoder_dense2_weight=Variable(85b99), decoder_dense2_bias=Variable(21241))\n",
-      "y ~ Normal(mean=f, variance=noise_var)\n"
+      "Model (95c68)\n",
+      "Variable (b8df3) = BroadcastToOperator(data=Variable noise_var (873b0))\n",
+      "Variable (36f25) = BroadcastToOperator(data=Variable (399cc))\n",
+      "Variable (6a234) = BroadcastToOperator(data=Variable (2fe44))\n",
+      "Variable x (1696c) ~ Normal(mean=Variable (6a234), variance=Variable (36f25))\n",
+      "Variable f (0d26d) = GluonFunctionEvaluation(decoder_input_0=Variable x (1696c), decoder_dense0_weight=Variable (89315), decoder_dense0_bias=Variable (41eac), decoder_dense1_weight=Variable (b69fe), decoder_dense1_bias=Variable (8e4e6), decoder_dense2_weight=Variable (a99ff), decoder_dense2_bias=Variable (f0361))\n",
+      "Variable y (5f5c3) ~ Normal(mean=Variable f (0d26d), variance=Variable (b8df3))\n"
      ]
     }
    ],
    "source": [
     "m = mf.models.Model()\n",
     "m.N = mf.components.Variable()\n",
-    "m.decoder = mf.components.functions.MXFusionGluonFunction(decoder, num_outputs=1,broadcastable=False)\n",
-    "m.x = mf.components.distributions.Normal.define_variable(mean=mx.nd.array([0]), variance=mx.nd.array([1]), shape=(m.N, Q))\n",
+    "m.decoder = MXFusionGluonFunction(decoder, num_outputs=1,broadcastable=True)\n",
+    "m.x = Normal.define_variable(mean=broadcast_to(mx.nd.array([0]), (m.N, Q)),\n",
+    "                             variance=broadcast_to(mx.nd.array([1]), (m.N, Q)), shape=(m.N, Q))\n",
     "m.f = m.decoder(m.x)\n",
-    "m.noise_var = mf.components.Variable(shape=(1,), transformation=PositiveTransformation(), initial_value=mx.nd.array([0.01]))\n",
-    "m.y = mf.components.distributions.Normal.define_variable(mean=m.f, variance=m.noise_var, shape=(m.N, D))\n",
+    "m.noise_var = Variable(shape=(1,), transformation=PositiveTransformation(), initial_value=mx.nd.array([0.01]))\n",
+    "m.y = Normal.define_variable(mean=m.f, variance=broadcast_to(m.noise_var, (m.N, D)), \n",
+    "                             shape=(m.N, D))\n",
     "print(m)"
    ]
   },
@@ -168,17 +155,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "x_mean = GluonFunctionEvaluation(encoder_input_0=y, encoder_dense0_weight=Variable(9768f), encoder_dense0_bias=Variable(9f1a0), encoder_dense1_weight=Variable(18970), encoder_dense1_bias=Variable(bcff4), encoder_dense2_weight=Variable(3d2a8), encoder_dense2_bias=Variable(95031))\n",
-      "x ~ Normal(mean=x_mean, variance=x_var)\n"
+      "Posterior (63197)\n",
+      "Variable x_mean (09eba) = GluonFunctionEvaluation(encoder_input_0=Variable y (5f5c3), encoder_dense0_weight=Variable (81ec2), encoder_dense0_bias=Variable (aa736), encoder_dense1_weight=Variable (3c4ae), encoder_dense1_bias=Variable (1bab5), encoder_dense2_weight=Variable (7b531), encoder_dense2_bias=Variable (84731))\n",
+      "Variable (f88b7) = BroadcastToOperator(data=Variable x_var (fc12e))\n",
+      "Variable x (1696c) ~ Normal(mean=Variable x_mean (09eba), variance=Variable (f88b7))\n"
      ]
     }
    ],
    "source": [
-    "q = mf.models.Posterior(m)\n",
-    "q.x_var = mf.components.Variable(shape=(1,), transformation=PositiveTransformation(), initial_value=mx.nd.array([1e-6]))\n",
-    "q.encoder = mf.components.functions.MXFusionGluonFunction(encoder, num_outputs=1, broadcastable=False)\n",
+    "q = Posterior(m)\n",
+    "q.x_var = Variable(shape=(1,), transformation=PositiveTransformation(), initial_value=mx.nd.array([1e-6]))\n",
+    "q.encoder = MXFusionGluonFunction(encoder, num_outputs=1, broadcastable=True)\n",
     "q.x_mean = q.encoder(q.y)\n",
-    "q.x.set_prior(mf.components.distributions.Normal(mean=q.x_mean, variance=q.x_var))\n",
+    "q.x.set_prior(Normal(mean=q.x_mean, variance=broadcast_to(q.x_var, q.x.shape)))\n",
     "print(q)"
    ]
   },
@@ -212,24 +201,33 @@
   {
    "cell_type": "code",
    "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "infr.initialize(y=mx.nd.array(Y))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
    "metadata": {
-    "scrolled": true
+    "scrolled": false
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Iteration 201 loss: 1715.0395507812525\n",
-      "Iteration 401 loss: 599.87670898437525\n",
-      "Iteration 601 loss: 149.24291992187538\n",
-      "Iteration 801 loss: -44.793395996093755\n",
-      "Iteration 1001 loss: -202.39929199218755\n",
-      "Iteration 1201 loss: -314.48220825195315\n",
-      "Iteration 1401 loss: -301.41076660156255\n",
-      "Iteration 1601 loss: -585.94531250937585\n",
-      "Iteration 1801 loss: -702.51806640625525\n",
-      "Iteration 2000 loss: -775.11627197265625"
+      "Iteration 201 loss: 1715.0395507812555\n",
+      "Iteration 401 loss: 599.86877441406255\n",
+      "Iteration 601 loss: 177.60995483398438\n",
+      "Iteration 801 loss: -75.347778320312555\n",
+      "Iteration 1001 loss: -213.82623291015625\n",
+      "Iteration 1201 loss: -332.34564208984375\n",
+      "Iteration 1401 loss: -305.57965087890625\n",
+      "Iteration 1601 loss: -577.47900390625585\n",
+      "Iteration 1801 loss: -669.97760009765625\n",
+      "Iteration 2000 loss: -753.83203125234385"
      ]
     }
    ],
@@ -246,7 +244,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from mxfusion.inference import TransferInference"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -255,17 +262,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXYAAAD8CAYAAABjAo9vAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAFlBJREFUeJzt3X+I3Hedx/HXeye7nKLUYpMoTbZrq4g/7hjbMVeRcFJ7sXc0EevJ6R1Szjb55wQFj3peQe4EuVNROM6Cl01FD0pFsGpalbZixQjGdLbMmcacR1oakqtkq5dWpYezu/O+PzYTNpvZnV+f7/fzmc/3+YCy3WYy89lJ85rPvL/vz3vM3QUAyMdU7AUAAMIi2AEgMwQ7AGSGYAeAzBDsAJAZgh0AMkOwA0BmCHYAyAzBDgCZ2RLjQa+66iqfm5uL8dAAMLEWFhZ+5e5b+90uSrDPzc2p2WzGeGgAmFhmdnqQ21GKAYDMEOwAkBmCHQAyQ7ADQGbGDnYz+wMzO2Zm/2lmJ8zsn0IsDAAwmhBdMb+XdJO7/87MpiX92My+5+5HA9w3AGBIY+/YfdXvLnw7feEfPpYJmFCtxZYOHT+k1mIr9lIwoiB97GZWk7Qg6bWS7nH3n/a4zQFJByRpdnY2xMMCCKy12NL+R/arvdLWTG1G83vmVd9Wj70sDCnIxVN3X3H3uqQdknaZ2Zt73OaguzfcvbF1a9+DUwAiaJ5rqr3SVkcdLXWW1DzHQcJJFLQrxt2fl/RDSbeEvF8A5Whsb2imNqOa1TQ9Na3G9kbsJWEEY5dizGyrpCV3f97MXiLpZkmfGXtlAEpX31bX/J55Nc811djeoAwzoULU2F8t6asX6uxTkr7u7g8FuF8AEdS31Qn0CTd2sLv7zyS9JcBaAAABcPIUADJDsANAZgh2AMgMwQ4AmSHYASAzBDsAZIZgB4DMEOwAkBmCHavOHJOOfH71K4CJFmRsLybcmWPSV/dJK22pNiPdfljauSv2qgCMiB07pGeOrIa6r6x+feZI7BUBGAPBDmlu9+pO3WqrX+d2x14RgDFQisFq2eX2w6s79bndlGGACUewY9XOXQQ6kAlKMQCQGYIdADJDsANAZgh2AMgMwQ4AmSHYASAzBDsAZIZgB4DMEOwAkBmCHQAyQ7ADQGYIdgDIDMEOAJkh2AEgMwQ7AGRm7GA3s51m9piZnTSzE2b2kRALAwCMJsQHbSxL+pi7P2FmL5e0YGaPuvvPA9w3ENzC6fM6+vSvdeO1r9QN11wZezlAcGMHu7v/UtIvL/z7b83spKSrJRHsSM7C6fP660NH1V7uaGbLlO6780bCHdkJWmM3szlJb5H005D3C4Ry9Olfq73cUcelpeWOjj7969hLqoTWYkuHjh9Sa7EVeymVEOwzT83sZZK+Iemj7v6bHr9+QNIBSZqdnQ31sMBQbrz2lZrZMqWl5Y6mt0zpxmtfGXtJ2WsttrT/kf1qr7Q1U5vR/J551bfVYy8ra0GC3cymtRrq97n7A71u4+4HJR2UpEaj4SEeFxjWDddcqfvuvJEae4ma55pqr7TVUUdLnSU1zzUJ9oKNHexmZpLulXTS3b8w/pKAYt1wzZUEeoka2xuaqc1oqbOk6alpNbY3Yi8peyF27G+X9EFJx82sW0D7B3f/boD7BjDh6tvqmt8zr+a5phrbG+zWSxCiK+bHkizAWgBkqr6tTqCXiJOnAKKgU6Y4wbpigBRw+Ggy0ClTLIId2eDw0eSgU6ZYlGKQDQ4fTY5up0zNanTKFIAdO7LB4aPJQadMscy9/LNCjUbDm81m6Y+L/FFjR87MbMHd+769YceOrHD4CKDGDgDZIdgBIDMEOwBkhmAHgMwQ7MjawunzuuexU1o4fT72UoDS0BWDbHESFVXFjh3Z4iQqqopgR7a6J1FrJk6iolIoxSBbfAweqopgR9Y4iYoqohQDFISOHMTCjh0oAB05iIkdO1AAOnIQE8EOFICOHMREKQYoAB05iIlgRxhnjknPHJHmdks7d8VeTRLoyEEsBDvGd+aY9NV90kpbqs1Itx8m3IGIqLFjfM8cWQ11X1n9+syR2CsCStdabOnQ8UNqLbZiL4UdOwKY2726U+/u2Od2x14RUKrWYkv7H9mv9kpbM7UZze+Zj/oB3QQ7xrdz12r5JaMaOx+KjWE0zzXVXmmro46WOktqnmsS7MjAzl1ZBLrE4SIMr7G9oZnajJY6S5qemlZjeyPqegh2YJ1eh4vWBzs7eqxV31bX/J55Nc811djeiLpblwIFu5l9WdKtkhbd/c0h7hOJqGAbY/dw0dJy5+LhorVBLokdPS5T31aPHuhdoXbsX5H0RUn/Eej+kIKKtjGuP1wkXRrkt12/o++OHogpSLC7+4/MbC7EfSEhvdoYKxDs0qWHi+557NQlQW7SZTt6ICXU2LEx2hglXV6aue36Hbrt+h3U2JEsc/cwd7S6Y39ooxq7mR2QdECSZmdnbzh9+nSQx0XBKlhj73VhNJWLpamsA3GY2YK79225KW3H7u4HJR2UpEajEebVBMXrhnn3NGnm4b5Rq2MKc19ow8SgGCmAzXUvoP7g06tfzxyLvaJCpTxHPeW1IS1Bgt3M7pf0E0mvN7OzZnZHiPtFAio2ByblOeopr60KBp0Fk8LMmFBdMR8IcT9IUMUuoIaYo15UHZwZ7/EMOgsmlZkxdMVgcxnOgellfRiPGppF18G799UtwxDu5dhsFkxrsXXxxGkqM2MIdvSX0RyYXhZOn9cH5o9ebGe8f//oYTzIOIJx18oF1PJtNAtm/Q79rrfelcTMGIIdlffAE2fVXu5IktrLHT3wxNmRw7LXOIKQin7hQG8bzYJZv0N/of1CEjNjCHZU3vre23F6cYuugxf9woGN9ZoF02snn8LMmGAHlIbRaDS82WyW/rjoo4KHkaQLpZiDP9HSimu6Zrr/wNuS3gVzSCkta2vsRQf6oAeUCPaUlRm0FR341UVYYhIkd/IUQyozaM8ck374z9Ly7yV1KjfwS1K0k6W8oKAIBHuqypqsePEF5EKoa6oS/epl2Sy46XBBUQj2VJV1MOjiC0hHsinp2ndI7/hEpXbrRekX3HS4oCgEe6rKOhi0/gWEUA+mX3DT4VI9ZV1oJdhTVsbBoFFeQCraPTOsfsHNiIBqKXPcAMGO4V5AKtg9M+oFzkGCO4VxwChHmeMGCHYMp2IflzfuBU6CG10bjSUoAsFOWWE4FZv2yAVOhLLRWIIiVDvYK1hWGFtFpj12FXWBk/71aipr3EC1g71iZYW+Bn33kvm0x7WKuMBJ/zqKVu1gr1hZYVO8e9lQvzr5sLtvyjsoWrWDvYiywqTW7Hn3MpD1IT7K7pv+dRSt2sEuhS0rTPKul3cvffUK8VF23/Svo2gE+zD67cYnedc7QRdFY1147BXio+6+aYNEkQj2QQ2yG5/0Xe8g714il5piXnjsFeLsvpEign1Qg+zGU9n1FhW+CZSaYl543CjE2X0jNQT7oAbdjcduBRw2fId5EUig1NTdNbeXOzIzXfnSmVIfnxDHJJiKvYCJ0d2N33R32hdFe4XvRrovAj/49OrXM8c2v+/ui5vVopWabrjmSn3y1jdpykwrHdenHjqhhdPnS18HkDJ27MOIvRsfxDB1/mF34ImUms6/2FbHXa60+sA5TYpUEOy5GSZ8R7nYm8CLW4p94JwmRUoI9hSNe/Fz0PBNZAc+rBQ7UThNipQQ7Kkpu/Nk2B14IidrU7uImeK7CFQXwZ6aBDpPNpRAu2OqUnwXgeoi2FPTq+6dyC456RedBKT2LgLVFSTYzewWSf8qqSbpkLv/S4j7raT1dW8pnV3ypJ+sjYRuGZRt7GA3s5qkeyT9qaSzkh43s8Pu/vNx77uy1ta9j3w+nV3yhF5sjYluGcQQYse+S9Ipd39akszsa5LeLYlgDyG1XXKR7Y6plJwColsGMYQI9qslnVnz/VlJf7z+RmZ2QNIBSZqdnQ3wsBVRlV1yphdmr3zpjKbMJDndMihNiJEC1uO/+WX/wf2guzfcvbF169YAD1shO3dJuz+WRdBtaJhRCBNi4fR5feqhE1rpuKbM9Mlb33TJbn3h9Hnd89gpRiIguBA79rOSdq75foekZwPc72gyfDtfCamVnALolmFckrvr/Ivti79G7R1FChHsj0t6nZm9RtL/SHq/pL8KcL/Dy/TtfOlivDhmWHK6OIly6fJJlNTeUaSxSzHuvizpw5IelnRS0tfd/cS49zuSDN/Ol27YiY8hZVZyujiJcsrU8UsnUXZDv2ai9o7ggvSxu/t3JX03xH2NJcO386ULcQgp43LYsD3p3UmU63fmnFRFkfI6eZrh2/nSjfvimHE5bJS6+GYzZCb9pGprsaXmuaYa2xuqb6vHXg7WyCvYpSTGyk60cV8cEx07EOL05yh18Vx35q3Flu54+A4tdZY0PTWte991L+GekPyCHeMb58UxwXJYqA6UUSc4TvrOvJfDTx1Wu7Pa5dPutHX4qcMEe0IIdoSVYDksVAdKrrvvUdi64yvrv0dckx/sGV+om1i9dvwR/5xCzkrPcfc9ir3X7dW3Tn3rYilm73V7Yy8Ja5j7ZYdEC9doNLzZbI5/RxlfqCtMjIBN4M+JCYvh9bp4ygXVYpnZgrs3+t1usnfsiV6oS1asgE3gz4mddnj1bfVLwru12NL+R/arvdLWTG1G83vmCfdIQsyKiad7oc5qyVyoG8uZY6tjeos6FBTrAFduf04V01ps6dDxQ2ottja9XfNcU+2VtjrqaKmzpOa5AO/KMZLJ3rEneKFuZGXspmN1rGTy51TFcs4wu/DG9oZmajMX6+6N7X0rBijIZAe7lE/fehnlipgBm8Cf0zjBXNWhXb124RsFe31bXfN75qmxJ2Dygz0XZe2mEwjYGMYN5qoO7eruwtsrbZlMV8xcsent19fdEcdk19hz0t1N33R3dbt7CrzG0CuYh1HVoV31bXXd9da7NGVT6nhHn338s31r7YiPHXtKKrqbllT4NYZxe9mrfDjphfYL6nhnoHJMP7RDlmOygp3DSMWJ/dwWfI0hRDBXtWVynIuia4NcEu2QJZmcYE/gkEu2UnhuS7jGUNVgHteoF0XXd9Tsu27fwBdiMZ7JCfYEDrlkK4XnNrGWyCq2Nm5mmIui3V36s7979pIgdzntkCWZnGBPcGpgNlJ5bhO5xlDV1sYQ1u7St0xt0ZapLVrxFU1PTWvfdfu077p91NhLMDnBntiOLis8t5eoamtjCGv73ld8Re993Xv16pe9+pIgJ9CLNznBLiWzo8sSz+1FIadBVs36C617r9tLkEcw2dMdgYJUscYeqhWxez9XzFyhF9ovUHYJqBrTHYGCVK2DJuRkxu7vo7UxHk6eYmNFT5tEMkJPZmTSY1zs2NFbCr3tKM2wh5D6lW2Y9BgXwY7eUuhtR2mGOYQ0SNmGSY9xEewbyPri2SDjA1LpbUdpBj2ENOgoXyY9xkOw95D1AZVBSyz0tmMDlFnSR7D3kPUBlWFKLPS2owfKLOmjK6aHrGdv8/mjKMign42K4rFj7yHr2duUWDCmXhdPJfrWUzJWsJvZ+yT9o6Q3SNrl7tk0q2Z9QIUSC8awUY86I3nTMe6O/UlJt0n69wBrATABNrp4utEFVT41qXxBZsWY2Q8l/d2gO3ZmxQCTrdc8GEmXBXjIUQVgVgyAAm00D+bOP7zzktsN2vOOsPp2xZjZ983syR7/vHuYBzKzA2bWNLPmc889N/qKASRhkHkw3bJNzWr0vJeo747d3W8O8UDuflDSQWm1FBPiPgHEM8hBpW7P+4NPPSgXf+3LQikGwEiGOah0+KnDaq+09eBTD1JnL8G47Y7vkfRvkrZK+o6Ztdz9XUFWBiB5g8yDoc5evrGC3d2/KembgdYCIEPMlikfpZiAYk+EjP34QC/MlikfwR5I7ImQsR8f2AwjfMtFsAcSayJkd5f+7PP/l+9ESiSLU6VpIthHtL7s0Z0IubTcKW0i5Npd+pYp05balFZWynt8VBunStNFsI9go7JH2RMh175LWOm4/nLXTl39ipdQY0cp6HZJF8E+go3KLmVPhFz/LuG91+8g0FEaul3SRbCPIEbZpZes58YjeXS7pCvIdMdh5TDdkdZCAGVjumPBsv4gDgATjc88BYDMEOwAkBmCHQAyQ7ADQGYIdgDIDMEOAJkh2AEgMwQ7AGSGYAeAzBDsAJAZgh0AMkOwAwVqLbZ06PghtRZbsZeCCmEIGFAQPmEIsbBjBwrS6xOGgDIQ7EBBup8wVLManzCEUlGKAQqy/hOGJOnQ8UN82hAKR7ADBapvq6u+rU69HaUi2IESbFRv5/NCUQSCHShBt96+1FnS9NS0rpi5gh08CkOwAyVYX2/vtYMn2BHKWMFuZp+TtFdSW9JTkv7G3Z8PsTAgN916e9faHTwdMwjJ3H3032y2R9IP3H3ZzD4jSe7+8X6/r9FoeLNJTy+qrbXYosaOoZjZgrv33QWMtWN390fWfHtU0l+Mc39AlazfwQOhhDyg9CFJ3wt4fwCAEfTdsZvZ9yW9qscv3e3u375wm7slLUu6b5P7OSDpgCTNzs6OtFiUa9hSAaUFIA19g93db97s183sdkm3Snqnb1Kwd/eDkg5KqzX2IdeJkg17oKbf7Qn9wfFcYVzjdsXcIunjkv7E3V8MsySkYNh2vM1uz6nLwfFcIYRxa+xflPRySY+aWcvMvhRgTUjAsAOsNrs9Uw4Hx3OFEMbtinltqIUgLesP1PTbNW52+/WnLunZ3hjPFUIYq499VPSxxxGzdkvdeHA8V9jIoH3sBHtFULsFJt+gwc4HbVQEtVugOgj2iuDTfIDqYLpjRQx7MRTA5CLYK4TZJEA1UIoBgMwQ7ACQGYIdADJDsANAZgh2AMgMwQ4AmYkyUsDMnpN0uuSHvUrSr0p+zJRU/eeXeA6q/vNLk/8cXOPuW/vdKEqwx2BmzUFmLOSq6j+/xHNQ9Z9fqs5zQCkGADJDsANAZqoU7AdjLyCyqv/8Es9B1X9+qSLPQWVq7ABQFVXasQNAJVQq2M3sc2b2X2b2MzP7ppm9IvaaymRm7zOzE2bWMbPsOwO6zOwWM/uFmZ0ys7+PvZ6ymdmXzWzRzJ6MvZZYzGynmT1mZicv/B34SOw1FalSwS7pUUlvdvc/kvTfkj4ReT1le1LSbZJ+FHshZTGzmqR7JP2ZpDdK+oCZvTHuqkr3FUm3xF5EZMuSPubub5B0o6S/zfn/g0oFu7s/4u7LF749KmlHzPWUzd1PuvsvYq+jZLsknXL3p929Lelrkt4deU2lcvcfSfrf2OuIyd1/6e5PXPj330o6KenquKsqTqWCfZ0PSfpe7EWgcFdLOrPm+7PK+C80+jOzOUlvkfTTuCspTnafoGRm35f0qh6/dLe7f/vCbe7W6luz+8pcWxkG+fkrxnr8N1rBKsrMXibpG5I+6u6/ib2eomQX7O5+82a/bma3S7pV0js9w17Pfj9/BZ2VtHPN9zskPRtpLYjIzKa1Gur3ufsDsddTpEqVYszsFkkfl7TP3V+MvR6U4nFJrzOz15jZjKT3SzoceU0omZmZpHslnXT3L8ReT9EqFeySvijp5ZIeNbOWmX0p9oLKZGbvMbOzkt4m6Ttm9nDsNRXtwsXyD0t6WKsXzL7u7ifirqpcZna/pJ9Ier2ZnTWzO2KvKYK3S/qgpJsu/N1vmdmfx15UUTh5CgCZqdqOHQCyR7ADQGYIdgDIDMEOAJkh2AEgMwQ7AGSGYAeAzBDsAJCZ/wfwkPjuAc1V6gAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXYAAAD8CAYAAABjAo9vAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAFiZJREFUeJzt3X2MXFd5x/Hfs5OdFglkosRrotiOSaAVNKqGZDBGKCoKaQgocUQqJEiFogK2KpUKJKrQNFJf/mobBGolIrXeNYJKKQg1EEwhyosUhJHqOLPRFDuYFyeKazfRrkONASFldnee/jE7Zjye3Zk7c+89d879fiRrM97J3DO7ye+eee5zzjV3FwAgHjOhBwAASBfBDgCRIdgBIDIEOwBEhmAHgMgQ7AAQGYIdACJDsANAZAh2AIjMZSEOeuWVV/quXbtCHBoAptbi4uIr7r512POCBPuuXbvUaDRCHBoAppaZnRrleZRiACAyBDsARIZgB4DIEOwAEBmCHQAiQ7ADQGQmDnYz+20zO2pm/21mz5nZ36UxMAD5ay43tXBsQc3lZuihYAJp9LG/Kulmd/+Vmc1K+r6ZPeruR1J4bQA5aS43te/xfWqttVStVDV/67xqc7XQw8IYJp6xe8ev1h/Orv/hRqrAlGksNdRaa6mttlbaK2ossYhwWqVSYzezipk1JS1LesLdnx7wnP1m1jCzxtmzZ9M4LIAU1bfVVa1UVbGKZmdmVd9WDz0kjMnc05tcm9nrJX1D0p+7+/GNnlev150tBYDiaS431VhqqL6tThmmgMxs0d2HnnFT3SvG3X9uZt+VdJukDYMdQDHV5moEegTS6IrZuj5Tl5m9RtItkn406esCAMaTxoz9KklfNrOKOieKr7n7f6bwugCAMUwc7O7+A0lvS2EsAIAUsPIUACJDsANAZAh2AIgMwQ4AkSHYASAyBDsARIZgB4DIEOwAEBmCHYOdPiod/lznK4CpkuomYIjE6aPSl/dKay2pUpXuOSTt2B16VABGxIwdl3rxcCfUfa3z9cXDoUcEIAGCHZfadVNnpm6VztddN4UeEYAEKMXgUjt2d8ovLx7uhDplGGCqEOwYbMduAh2YUpRiACAyBDsARIZgB4DIEOwAEBmCHQAiQ7ADQGQIdgCIDMEOAJEh2AEgMgQ7AESGYAeAyBDsABAZgh0AIkOwA0BkCHYAiMzEwW5mO8zsKTM7YWbPmdkn0xgYAGA8adxoY1XSp939WTN7naRFM3vC3X+YwmsDmVo8dU5HXviZ9lx7hW685vLQwwFSMXGwu/vLkl5e/+dfmtkJSVdLIthRaIunzumPF46otdpW9bIZPfTxPYQ7opBqjd3Mdkl6m6SnB3xvv5k1zKxx9uzZNA8LjOXICz9Ta7Wttksrq20deeFnoYcEpCK1YDez10p6WNKn3P0X/d939wPuXnf3+tatW9M6LDC2PddeoeplM6qYNHvZjPZce0XoIUWludzUwrEFNZeboYdSOqnczNrMZtUJ9Yfc/etpvCaQtRuvuVwPfXwPNfYMNJeb2vf4PrXWWqpWqpq/dV61uVroYZXGxMFuZibpoKQT7v75yYcE5OfGay4n0DPQWGqotdZSW22ttFfUWGoQ7DlKoxTzLkkfkXSzmTXX/7w/hdcFMKXq2+qqVqqqWEWzM7Oqb6uHHlKppNEV831JlsJYAESiNlfT/K3zaiw1VN9WZ7aes1Rq7ADQrzZXI9ADYUsBRGvx1Dk9+NRJLZ46F3oo6EG3TPaYsSNKLD4qJrpl8sGMHVFi8VExDeqWQfoIdkSJxUfFRLdMPszdcz9ovV73RoMzNbLFBl/F1Fxu0i0zJjNbdPehZ0OCHQCmxKjBTikGACJDsANAZAh2AIgMwQ4AkSHYURqsREVZsPIUpcBKVJQJM3aUAitRUSYEO0qBlagoE0oxKAVug4cyIdhRGtwGD2VBKQYAIkOwAzmh3RJ5oRQD5IB2S+SJGTuQA9otkSeCHdk4fVQ6/LnOV9BuiVxRikH6Th+VvrxXWmtJlap0zyFpx+7QowqKdkvkiWBH+l483Al1X+t8ffFw6YNdot0S+aEUg/TtuqkzU7dK5+uum0KPCMhcc7mphWMLai43Qw+FGTsysGN3p/zy4uFOqDNbR+Say03te3yfWmstVStVzd86H/R+rgQ7srFj99QHOjfDxqgaSw211lpqq62V9ooaSw2CHSga+s6RRH1bXdVKVSvtFc3OzKq+bej9pjNFsGN0p4+WprwyqO98ULAzq4ck1eZqmr91Xo2lhurb6kFn61JKwW5mX5R0u6Rld78+jddEwZSshbHbd76y2r6o77w3yCUxq8cFtbla8EDvSmvG/iVJX5D0bym9HoqmZC2Mg/rO+8szd92wfaRZPZC3VILd3b9nZrvSeC0UVLeFsTtjL0ELY3/feX95xqSBs3ogtNxq7Ga2X9J+Sdq5c2deh0VaaGG8pDxz1w3bddcN26mxo3ByC3Z3PyDpgCTV63XP67jAuPovjG60LQCBjqKhKwajKdnF043aHdkWANOALQUwmkEXTyNW5G12uWFH8YXeXiCtdsevSHq3pCvN7Iykv3H3g2m8NgqiZBdPN2p3DI2FU2E1l5tDe9WLsL1AWl0xH07jdVBgJbt4WtRtdkddOIX0bRbYvYFfhO0FqLFjdBHs/7KZf3/6f/To8Zf1vuuv0t3v2DlRPT2rFalF/SRRBhsFdn/g3/v2e4NvL0CwA+qE+l9945gk6fBPX5Ek3f2O8dpysyyXFPWTRBlstB9Mf+Cfb50Pvr0AwY6LlWg/mF6PHn/5ksfjBjvlkjhttB/MoMAPvb0AwY7fKFlLY6/3XX/VhZl69/G4siyXcPE0rEGBXbQNwCSCvfjymkGfPip99++l1VcltUuxH0yv7uy8t8Y+rizLJXwaKKbQM/R+BHuR5TWDvnCc9VDXTClaGvvd/Y6dEwV6r6wWMnHxFKMg2Issrx0VLxynLdmMdO27pXffV5rZ+jTh4ilGQbAXWV6LgvqPQ6inIquWR7Y1wDAEe5HltSgo6XFK2jmTxKgXObkDU7mMsnI1DQR70eW1KGjU45S4cyaJUS5y0uFSLnluNcAmYEimZJuBjat7kbNi2vAiZ5E3GkP6Bq1czQoz9l6UGIYr2WZg0njlklEuctLhUi4brVzNgrnnf8+Ler3ujUZ2Z6uxUGIYXYlOgFmXS6ixl8ukNXYzW3T3oWcEZuxdJbtZ80CjBnbkm4H1ynpBEB0u5ZLXQiaCvauEJYaL8IllIMolmEYEe1fJ9hu/BJ9YBspqQRAlGGSJYO+VZolh2urQZf/Esom0yyW0OSJrBHtSowT2NJY1puwTS6gZ76DjJh0LG3khawR7EqMG9rSWNZIsUgp4Agg14x10XEmJx0LdHlkj2JMYNbBjLmsU4NNIqBnvRguKko6FjbyQNYI9iVEDO3RZI8sZdQE+jey59gpdVunMeCuV/Ga8G820x5l90+aILBHsSSQJ7FC93kln1ElPAkX5NNJdWJfjAruNZtrMvlE0BHtSRV+ck2RGPU5ZJfSnEXVKIqttl0taa3uuFx8HzbSZfaNoCPbYJJlRj1tWCXxy4+IjsDmCPTZJZtRFKaskVMSLjyw4QpGwCVhR5XkT6yTHmbaFVzlgwRHywiZg0yzPlsIkZZUCtDoWEQuOUDTcaKOIBtW+Tx+VDn+u87VI48JIN9UA8sSMvYj6a9+vuaIYM+UprclnrYg1f5RbKsFuZrdJ+mdJFUkL7v4PabxuafVfAC3AoqCB46IMcwEtjyiSiYPdzCqSHpT0h5LOSHrGzA65+w8nfe1S6699F2WmnGWrY6QXZumYQd7SmLHvlnTS3V+QJDP7qqQ7JRHsaSnDTDnSC7N0zCCENC6eXi3pdM/jM+t/dxEz229mDTNrnD17NoXDlsyO3dJNn44i7AaK9MLsRhuHAVlKI9htwN9d0hzv7gfcve7u9a1bt6Zw2A0UoXsEyXUvzFolfLkpRXTMIIQ0SjFnJO3oebxd0kspvG5ykX6cz12IWneE5aZubf2vb/89nft1ixo7cpNGsD8j6c1m9kZJ/yvpQ5LuTuF1kytK98g0C3lyLPoGawkMq61zQRVZmjjY3X3VzD4h6TF12h2/6O7PTTyycdBnPbk0To6Rdrck0Vtbf3WlrYefPXPRrfS4oIospdLH7u7fkfSdNF5rIhF+nM/dpCdHymGS1m8GMmNqrXW2F/6PxTP6oxu268ZrLmcLAmQuvi0FYu8eyVr35Hjz/eOFcqTdLVJnpv3gUye1eOrc0OfeeM3l+mB9x4XOgrW133TExHJBtbnc1MKxBTWXm6GHgj5sKYBLTVLrLmA5LI169jjlk7tu2K6Hnz1zyb7xMWxB0Fxu6mOPfUwr7RXNzszq4HsPqjZXCz0srCPYka6ClcPSqmePUz7ZLMCnfQuCQ88fUqvdkiS12i0dev4QwV4g0x/sXKgrno1m/AF+V2nVs8e9a9O0B/hGrG/5Sv9jhDXdwc6FumRCngQD/a7Suo1eDOWTNN1x3R165OQjF0oxd1x3R+ghocd0Bzt966MLfRIM9LtKM5BjnX2PozZX08H3HlRjqaH6trpqczU1l5sXPUY40x3sBbxQV1ihT4IBf1cEcjZqc7ULAd5cbmrf4/vUWmupWqlq/tZ5wj2g6Q72gl2om0jWZZLQJ8GYflclNGw23lhqqLXWUlttrbRX1FhqEOwBTXewS3EsQ8+jTFKEYI3hd1VCo8zG69vqqlaqF2ru9W1D77eMDE1/sMcgrzJJkYM1408sk/ayl3lvl1Fm47W5muZvnafGXhAEexGELpOElvEnlkl72cu+t0t3Nt5aa8lk2lLdMvB5vTV3hDVdWwrEutf6pMv4p13G2xBMerOLst8sozZX071vv1czNqO2t/XAMw+wjUDBTc+MPXS7XtZCl0lC9rhn/Ill0l72tHrhp9n51nm1vT3xxVFaIvMxPcEeul0vZqFPmhlf2J20l53FSeNfHO0Nckm0ROZkeoK97HXoLBXhpJnxJ5ZJe9nL3guf9OJoc7mpbz3/LT1y8hGttldVrVS197q9tETmZHqCvQjterHipIkRjHpxtNse+eraq/L12x+vtFfkcloiczI9wS6Fr0PHipPmRcrc2piGbntkN9RNptmZWe29bq/2XreXGnsOpivYkR1OmpJobUxDbz2+YhXd+aY7tfe6vReCnEDPHsEO9OC2dZPrrcdvqW7R+db50EMqHYId6FH21sa02hG7/y5dMGEQ7NhYCW9iUubWxrR3aGRjsHAIdgwWurc9oLK2NqYdxGwMFg7BXkajzMSL0NuOXCUN4mFlGzYGC4dgL5tRZ+L0tpdOkiAetWzDxmBhEOxlM+pMnN72Uho1iKmfFxvBPkDUC1SSzMTpbccGqJ8Xm7l77get1+veaDRyP+4oSrFApYTdLkjfoBo7uzdmy8wW3X3oWZQZe59SLFBhJo4UdIO7sfSbSRp968VAsPcp+wIVYFT9F1DZvbE4Jgp2M/ugpL+V9BZJu929mPWVBMq8QAVIov8CKrs3FsekM/bjku6S9K8pjKUwyrpABUiif7MvSbr37ffqfOv8JTV2au/5mijY3f2EJJlZOqMBMDW6fe/dG2o8/JOHB9bW096qAMPldjNrM9tvZg0za5w9ezavwwLIUG2upqtee5VW26sX1dZ7Dep5R7aGBruZPWlmxwf8uTPJgdz9gLvX3b2+devW8UcMoFC6JZmKVQbW1nu/X7GKXvrVS2ouNwONthxS6WM3s+9K+otRL54WuY8dQHLDauiD7oFKSSY5+tgB5GbYVgS1uZoaS41LSjYEezYmqrGb2QfM7Iykd0r6tpk9ls6wAMRmWMkG6WFLgYhEvccNokDb42QoxeQsdKiWYo8bTD228c0HwZ6C0KG6eOqc/unJn8S/xw2AkeTWxx6zQRuH5aV7Uvn+T19R26UZE3vcIHfN5aYWji3QxlgQzNgTGlRyCblxWPek4uqcpd/1piv1qVt+h9k6csPK0uIh2BPYqOQScuOw/pMKoY68cTel4iHYE9hsr/ZQG4exGyVC425KxUOwJ1DUvdrZjRIhJbkJNvJBH3tCodsaAZQXfewZYXYMoOhodwSAyBDsABAZgh0AIkOwA0BkCHYAiAzBDgCRIdgBIDIEOwBEhmAHgMgQ7AAQGYIdyBA3oEAI7BUDZIQbUCAUZuxARgbdgALIA8EOZKR7A4qKVTQ7M6st1S2UZZALSjFARnpvQLGlukUPPPMAZRnkgmAHMlSbq6k2V9PCsYWBZRnuOoQsEOxADvrvC7qluoULq8gMwQ7koP++oIMurBLsSAvBDuSkW5bp6p3B17cNvY0lMLKJgt3MPivpDkktSc9L+hN3/3kaAwNi1j+DZ7aONE06Y39C0n3uvmpm/yjpPkmfmXxYQPz6Z/BAWibqY3f3x919df3hEUnbJx8SAGASaS5Q+qikR1N8PQDAGIaWYszsSUlvGPCt+939m+vPuV/SqqSHNnmd/ZL2S9LOnTvHGizy01xuJqr/Jn0+gOwMDXZ3v2Wz75vZPZJul/Qed/dNXueApAOSVK/XN3wewku6eRWbXaWLkyQmNWlXzG3qXCz9A3f/dTpDQmhJe6yHPZ+gGh0nSaRh0q6YL0j6LUlPmJkkHXH3P514VAiqf5XksB7rzZ5PUCXDwiWkYaJgd/c3pTUQFEfSHuvNnk9QJZP0pAoMwsrTkkhaDknaY73R8wmqZFi4hDTYJtc7M1Ov173R4KYDeQldDqHGDqTDzBbdfejsiBl7CYQuh7DCEsgXd1Aqgf47+VAOAeLGjL0EqNsC5UKwlwTlEKA8KMUAQGQIdgCIDMEOAJEh2AEgMgQ7AESGYAeAyATZUsDMzko6lfuBpSslvRLguEVR9vcv8TMo+/uXpvtncI27bx32pCDBHoqZNUbZZyFWZX//Ej+Dsr9/qRw/A0oxABAZgh0AIlO2YD8QegCBlf39S/wMyv7+pRL8DEpVYweAMijbjB0Aole6YDezz5rZj8zsB2b2DTN7fegx5cnMPmhmz5lZ28yi7gzoZWa3mdmPzeykmf1l6PHkzcy+aGbLZnY89FhCMLMdZvaUmZ1Y/+//k6HHlKXSBbukJyRd7+6/L+knku4LPJ68HZd0l6TvhR5IXsysIulBSe+T9FZJHzazt4YdVe6+JOm20IMIaFXSp939LZL2SPqzmP8bKF2wu/vj7r66/vCIpO0hx5M3dz/h7j8OPY6c7ZZ00t1fcPeWpK9KujPwmHLl7t+T9H+hxxGKu7/s7s+u//MvJZ2QdHXYUWWndMHe56OSHg09CGTuakmnex6fUcT/U2NzZrZL0tskPR12JNmJ8g5KZvakpDcM+Nb97v7N9efcr87Hs4fyHFseRnn/JWMD/o52sBIys9dKeljSp9z9F6HHk5Uog93db9ns+2Z2j6TbJb3HI+z3HPb+S+iMpB09j7dLeinQWBCImc2qE+oPufvXQ48nS6UrxZjZbZI+I2mvu/869HiQi2ckvdnM3mhmVUkfknQo8JiQIzMzSQclnXD3z4ceT9ZKF+ySviDpdZKeMLOmmf1L6AHlycw+YGZnJL1T0rfN7LHQY8ra+sXyT0h6TJ2LZl9z9+fCjipfZvYVSf8l6XfN7IyZfSz0mHL2LkkfkXTz+v/3TTN7f+hBZYWVpwAQmTLO2AEgagQ7AESGYAeAyBDsABAZgh0AIkOwA0BkCHYAiAzBDgCR+X8tA7ZLJcL0MgAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
      },
-     "metadata": {},
+     "metadata": {
+      "needs_background": "light"
+     },
      "output_type": "display_data"
     }
    ],

--- a/mxfusion/components/functions/function_evaluation.py
+++ b/mxfusion/components/functions/function_evaluation.py
@@ -58,17 +58,19 @@ class FunctionEvaluation(Factor):
         :returns: the outcome of the function evaluation
         :rtypes: MXNet NDArray or MXNet Symbol or [MXNet NDArray or MXNet Symbol]
         """
-        kwargs = {name: variables[var.uuid] for name, var in self.inputs
-                  if not var.isInherited or var.type == VariableType.RANDVAR}
+
         if self.broadcastable:
             # If some of the inputs are samples and the function is
             # broadcastable, evaluate the function with the inputs that are
             # broadcasted to the right shape.
+            kwargs = {name: variables[var.uuid] for name, var in self.inputs if not var.isInherited}
             kwargs = broadcast_samples_dict(F, kwargs)
+            kwargs.update({name: variables[var.uuid][0] for name, var in self.inputs if var.isInherited})
             results = self.eval_impl(F=F, **kwargs)
             results = results if isinstance(results, (list, tuple)) \
                 else [results]
         else:
+            kwargs = {name: variables[var.uuid] for name, var in self.inputs}
             # If some of the inputs are samples and the function is *not*
             # broadcastable, evaluate the function with each set of samples
             # and concatenate the output variables.

--- a/mxfusion/components/functions/gluon_func_eval.py
+++ b/mxfusion/components/functions/gluon_func_eval.py
@@ -36,22 +36,3 @@ class GluonFunctionEvaluation(FunctionEvaluationWithParameters):
             func=func, input_variables=input_variables,
             output_variables=output_variables, broadcastable=broadcastable
         )
-
-    @property
-    def _input_to_gluon_names(self):
-        return [k for k, v in self.inputs if (not v.isInherited) or
-                v.type != VariableType.PARAMETER]
-
-    def eval_impl(self, F, **input_kws):
-        """
-        Invokes the MXNet Gluon block with the arguments passed in.
-
-        :param F: the MXNet computation mode (mxnet.symbol or mxnet.ndarray)
-        :param input_kws: the dict of inputs to the functions. The key in the dict should match with the name of
-        inputs specified in the inputs of FunctionEvaluation.
-        :type input_kws: {variable name: MXNet NDArray or MXNet Symbol}
-        :returns: the return value of the function
-        :rtypes: MXNet NDArray or MXNet Symbol
-        """
-        inputs_func = {k: input_kws[k] for k in self._input_to_gluon_names}
-        return self._func.eval(F, **inputs_func)

--- a/mxfusion/components/functions/mxfusion_gluon_function.py
+++ b/mxfusion/components/functions/mxfusion_gluon_function.py
@@ -158,30 +158,10 @@ class MXFusionGluonFunction(MXFusionFunction):
         params = block.collect_params()
         vs = {}
         for param in params.values():
-            v = Variable(isInherited=True, shape=param.shape)
+            v = Variable(isInherited=True, shape=param.shape, initial_value=param.data())
             v.inherited_name = param.name
             vs[v.inherited_name] = v
         return vs
-
-    def collect_gluon_parameters(self):
-        """
-        Return the parameters of the MXNet Gluon block that have *not* been set a prior distribution.
-
-        :returns: the parameters of the MXNet Gluon block without a prior distribution.
-        :rtype: MXNet.gluon.ParameterDict
-        """
-        params = ParameterDict()
-        gluon_params = self._gluon_block.collect_params()
-        params.update({var_name: gluon_params[var_name] for var_name, var in self._gluon_parameters.items()
-                       if var.type == VariableType.PARAMETER})
-        return params
-
-    def collect_params(self):
-        """
-        Return a variable set / dict. Used for the function.collect_params.set_prior() functionality.
-        """
-        # TODO: implement VariableSet
-        raise NotImplementedError
 
     def _override_block_parameters(self, input_kws):
         """

--- a/mxfusion/inference/inference_alg.py
+++ b/mxfusion/inference/inference_alg.py
@@ -182,8 +182,6 @@ class InferenceAlgorithm(ABC):
             for v in g.variables.values():
                 if v.type == VariableType.PARAMETER and v.transformation is not None:
                     var_trans[v.uuid] = v.transformation
-                if v.type == VariableType.PARAMETER and v.isInherited:
-                    excluded.add(v.uuid)
                 if v.type == VariableType.RANDVAR:
                     if v.uuid in rv_scaling:
                         v.factor.log_pdf_scaling = rv_scaling[v.uuid]

--- a/mxfusion/models/factor_graph.py
+++ b/mxfusion/models/factor_graph.py
@@ -450,7 +450,7 @@ class FactorGraph(object):
                 setattr(new_model, v.name, new_model[v.uuid])
         return new_model
 
-    def get_parameters(self, excluded=None, include_inherited=False):
+    def get_parameters(self, excluded=None, include_inherited=True):
         """
         Get all the parameters not in the excluded list.
 
@@ -580,9 +580,9 @@ class FactorGraph(object):
             reconcile_direction('predecessor', previous_graph[previous_c], current_graph[current_c], new_level,
                                 component_map)
             """
-            TODO Reconciling in both directions currently breaks the reconciliation process and can cause multiple 
-            previous_uuid's to map to the same current_uuid. It's unclear why that happens. This shouldn't be necessary 
-            until we implement multi-output Factors though (and even then, only if not all the outputs are in a 
+            TODO Reconciling in both directions currently breaks the reconciliation process and can cause multiple
+            previous_uuid's to map to the same current_uuid. It's unclear why that happens. This shouldn't be necessary
+            until we implement multi-output Factors though (and even then, only if not all the outputs are in a
             named chain).
             """
             # reconcile_direction('successor', previous_graph[c], current_graph[current_c], new_level, component_map)

--- a/mxfusion/modules/module.py
+++ b/mxfusion/modules/module.py
@@ -410,8 +410,6 @@ class Module(Factor):
             for v in g.variables.values():
                 if v.type == VariableType.PARAMETER and v.transformation is not None:
                     var_trans[v.uuid] = v.transformation
-                if v.type == VariableType.PARAMETER and v.isInherited:
-                    excluded.add(v.uuid)
                 if v.type == VariableType.RANDVAR:
                     if v.uuid in rv_scaling:
                         v.factor.log_pdf_scaling = rv_scaling[v.uuid]

--- a/testing/components/factor_test.py
+++ b/testing/components/factor_test.py
@@ -41,7 +41,8 @@ class FactorTests(unittest.TestCase):
         self.D = 10
         self.net = nn.HybridSequential()
         with self.net.name_scope():
-            self.net.add(nn.Dense(self.D, activation="relu"))
+            self.net.add(nn.Dense(self.D, in_units=1, activation="relu"))
+        self.net.initialize()
 
         m = mf.models.Model(verbose=False)
         f = MXFusionGluonFunction(self.net, num_outputs=1)

--- a/testing/components/functions/mxfusion_gluon_function_test.py
+++ b/testing/components/functions/mxfusion_gluon_function_test.py
@@ -33,7 +33,8 @@ class TestMXFusionGluonFunctionTests(object):
         self.D = 10
         self.net = nn.HybridSequential()
         with self.net.name_scope():
-            self.net.add(nn.Dense(self.D, activation="relu"))
+            self.net.add(nn.Dense(self.D, in_units=1, activation="relu"))
+        self.net.initialize()
 
     def _make_gluon_function_evaluation(self, dtype, broadcastable):
         class Dot(HybridBlock):

--- a/testing/components/functions/mxfusion_gluon_function_test.py
+++ b/testing/components/functions/mxfusion_gluon_function_test.py
@@ -174,6 +174,6 @@ class TestMXFusionGluonFunctionTests(object):
         m.f = MXFusionGluonFunction(self.net, num_outputs=1)
         m.y = m.f(m.x)
 
-        infr = Inference(ForwardSamplingAlgorithm(m, observed=[m.x, m.y]))
-        infr.initialize(x=(1, 1), y=(1, 10))
+        infr = Inference(ForwardSamplingAlgorithm(m, observed=[m.x]))
+        infr.run(x=mx.nd.ones((1, 1)))
         assert all([v.uuid in infr.params.param_dict for v in m.f.parameters.values()])

--- a/testing/inference/inference_serialization_test.py
+++ b/testing/inference/inference_serialization_test.py
@@ -222,14 +222,15 @@ class InferenceSerializationTests(unittest.TestCase):
 
     def test_gluon_func_save_and_load(self):
         m = self.make_simple_gluon_model()
-        infr = Inference(ForwardSamplingAlgorithm(m, observed=[m.x, m.y]))
-        infr.initialize(x=(1, 1), y=(1, 10))
+        infr = Inference(ForwardSamplingAlgorithm(m, observed=[m.x]))
+        infr.run(x=mx.nd.ones((1, 1)))
         infr.save(self.ZIPNAME)
 
         m2 = self.make_simple_gluon_model()
-        infr2 = Inference(ForwardSamplingAlgorithm(m2, observed=[m2.x, m2.y]))
-        infr2.initialize(x=(1, 1), y=(1, 10))
+        infr2 = Inference(ForwardSamplingAlgorithm(m2, observed=[m2.x]))
+        infr2.run(x=mx.nd.ones((1, 1)))
         infr2.load(self.ZIPNAME)
+        infr2.run(x=mx.nd.ones((1, 1)))
 
         for n in m.f.parameter_names:
             assert np.allclose(infr.params[getattr(m.y.factor, n)].asnumpy(), infr2.params[getattr(m2.y.factor, n)].asnumpy())

--- a/testing/models/factor_graph_test.py
+++ b/testing/models/factor_graph_test.py
@@ -68,9 +68,9 @@ class FactorGraphTests(unittest.TestCase):
         D = 100
         net = nn.HybridSequential(prefix='hybrid0_')
         with net.name_scope():
-            net.add(nn.Dense(D, activation="tanh"))
-            net.add(nn.Dense(D, activation="tanh"))
-            net.add(nn.Dense(2, flatten=True))
+            net.add(nn.Dense(D, in_units=10, activation="tanh", flatten=False))
+            net.add(nn.Dense(D, in_units=D, activation="tanh", flatten=False))
+            net.add(nn.Dense(2, in_units=D, flatten=False))
         net.initialize(mx.init.Xavier(magnitude=3))
         return net
 
@@ -96,7 +96,8 @@ class FactorGraphTests(unittest.TestCase):
         self.D = 10
         self.basic_net = nn.HybridSequential()
         with self.basic_net.name_scope():
-            self.basic_net.add(nn.Dense(self.D, activation="relu"))
+            self.basic_net.add(nn.Dense(self.D, in_units=10, activation="relu"))
+        self.basic_net.initialize()
         self.bnn_net = self.make_net()
 
     def test_bnn_model(self):
@@ -291,8 +292,8 @@ class FactorGraphTests(unittest.TestCase):
         self.assertTrue(len(component_map) == len(set(m1.components).union(set(m1.Y.factor._module_graph.components)).union(set(m1.Y.factor._extra_graphs[0].components))))
 
     def test_reconcile_model_and_posterior(self):
-        x = np.random.rand(1000, 1)
-        y = np.random.rand(1000, 1)
+        x = np.random.rand(1000, 10)
+        y = np.random.rand(1000, 10)
         x_nd, y_nd = mx.nd.array(y), mx.nd.array(x)
 
         net1 = self.make_net()


### PR DESCRIPTION
At the moment, the parameters of the Gluon blocks that are used in a MXFusion model need to be managed separately outside the InferenceParameters class of MXFusion. This change unifies the control of the parameters. With this change, all the parameters in Gluon blocks will also be managed in the InferenceParameters class.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
