### PR TITLE
Add TensorBoard logs for Inference

### DIFF
--- a/examples/notebooks/api_faq.ipynb
+++ b/examples/notebooks/api_faq.ipynb
@@ -92,6 +92,36 @@
     "mx.context.Context.device_ctx = mx.gpu()\n",
     "```"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. How to view TensorBoard logs?\n",
+    "\n",
+    "To use TensorBoard to inspect inference logs you must have TensorBoard and MXBoard installed. Instructions for installing these packages can be found [here](https://github.com/awslabs/mxboard).\n",
+    "\n",
+    "To produce the logs required for TensorBoard, pass a ```Logger``` with a ```log_dir``` (and an optional ```log_name```) to your inference object instantiation.\n",
+    "\n",
+    "```python\n",
+    "infr = Inference(logger=Logger(log_dir='logs'))\n",
+    "```\n",
+    "\n",
+    "To run the TensorBoard server to view the results, run the following command (for more details see [here](https://www.tensorflow.org/guide/summaries_and_tensorboard)):\n",
+    "```\n",
+    "$ tensorboard --logdir=path/to/log-directory\n",
+    "```\n",
+    "\n",
+    "Now you can open the server in a browser and view the logs.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -110,7 +140,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.6.1"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/getting_started.ipynb
+++ b/examples/notebooks/getting_started.ipynb
@@ -159,8 +159,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Model (006af)\n",
-      "Variable Y (407ed) ~ Normal(mean=Variable mu (ae180), variance=Variable s (24199))\n"
+      "Model (a5dc3)\n",
+      "Variable Y (bcabb) ~ Normal(mean=Variable mu (db4e7), variance=Variable s (d4985))\n"
      ]
     }
    ],
@@ -205,9 +205,8 @@
     "from mxfusion.inference import GradBasedInference, MAP, Logger\n",
     "import mxnet as mx\n",
     "\n",
-    "infr = GradBasedInference(inference_algorithm=MAP(model=m, observed=[m.Y]))\n",
-    "with Logger() as ll:\n",
-    "    infr.run(Y=mx.nd.array(data, dtype='float64'), learning_rate=0.1, max_iter=2000, logger=ll)"
+    "infr = GradBasedInference(inference_algorithm=MAP(model=m, observed=[m.Y]), logger=Logger())\n",
+    "infr.run(Y=mx.nd.array(data, dtype='float64'), learning_rate=0.1, max_iter=2000)"
    ]
   },
   {
@@ -315,11 +314,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Model (4d361)\n",
-      "Variable s_hat (0f46e) ~ Normal(mean=Variable (57766), variance=Variable (89a6a))\n",
-      "Variable s (e08eb) = GluonFunctionEvaluation(hybridlambda0_input_0=Variable s_hat (0f46e))\n",
-      "Variable mu (39398) ~ Normal(mean=Variable (bba5c), variance=Variable (cf3b1))\n",
-      "Variable Y (6dc0c) ~ Normal(mean=Variable mu (39398), variance=Variable s (e08eb))\n"
+      "Model (6f1c8)\n",
+      "Variable s_hat (084af) ~ Normal(mean=Variable (f7187), variance=Variable (272e3))\n",
+      "Variable s (aa166) = GluonFunctionEvaluation(hybridlambda0_input_0=Variable s_hat (084af))\n",
+      "Variable mu (9da62) ~ Normal(mean=Variable (c59d3), variance=Variable (97ca1))\n",
+      "Variable Y (e0522) ~ Normal(mean=Variable mu (9da62), variance=Variable s (aa166))\n"
      ]
     }
    ],
@@ -346,9 +345,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Posterior (01a55)\n",
-      "Variable s_hat (0f46e) ~ Normal(mean=Variable (20a5e), variance=Variable (6f639))\n",
-      "Variable mu (39398) ~ Normal(mean=Variable (7bf67), variance=Variable (31b9f))\n"
+      "Posterior (4cdab)\n",
+      "Variable s_hat (084af) ~ Normal(mean=Variable (7bf00), variance=Variable (aa526))\n",
+      "Variable mu (9da62) ~ Normal(mean=Variable (3e607), variance=Variable (a2372))\n"
      ]
     }
    ],
@@ -392,9 +391,8 @@
     "from mxfusion.inference import StochasticVariationalInference\n",
     "\n",
     "infr = GradBasedInference(inference_algorithm=StochasticVariationalInference(\n",
-    "    model=m, posterior=q, num_samples=10, observed=[m.Y]))\n",
-    "with Logger() as ll:\n",
-    "    infr.run(Y=mx.nd.array(data, dtype='float64'), learning_rate=0.1, logger=ll)"
+    "    model=m, posterior=q, num_samples=10, observed=[m.Y]), logger=Logger())\n",
+    "infr.run(Y=mx.nd.array(data, dtype='float64'), learning_rate=0.1)"
    ]
   },
   {

--- a/examples/notebooks/getting_started.ipynb
+++ b/examples/notebooks/getting_started.ipynb
@@ -159,8 +159,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Model (a5dc3)\n",
-      "Variable Y (bcabb) ~ Normal(mean=Variable mu (db4e7), variance=Variable s (d4985))\n"
+      "Model (26eec)\n",
+      "Variable Y (ba4f1) ~ Normal(mean=Variable mu (00629), variance=Variable s (ad2fd))\n"
      ]
     }
    ],
@@ -205,8 +205,8 @@
     "from mxfusion.inference import GradBasedInference, MAP, Logger\n",
     "import mxnet as mx\n",
     "\n",
-    "infr = GradBasedInference(inference_algorithm=MAP(model=m, observed=[m.Y]), logger=Logger())\n",
-    "infr.run(Y=mx.nd.array(data, dtype='float64'), learning_rate=0.1, max_iter=2000)"
+    "infr = GradBasedInference(inference_algorithm=MAP(model=m, observed=[m.Y]))\n",
+    "infr.run(Y=mx.nd.array(data, dtype='float64'), learning_rate=0.1, max_iter=2000, verbose=True)"
    ]
   },
   {
@@ -314,11 +314,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Model (6f1c8)\n",
-      "Variable s_hat (084af) ~ Normal(mean=Variable (f7187), variance=Variable (272e3))\n",
-      "Variable s (aa166) = GluonFunctionEvaluation(hybridlambda0_input_0=Variable s_hat (084af))\n",
-      "Variable mu (9da62) ~ Normal(mean=Variable (c59d3), variance=Variable (97ca1))\n",
-      "Variable Y (e0522) ~ Normal(mean=Variable mu (9da62), variance=Variable s (aa166))\n"
+      "Model (529df)\n",
+      "Variable s_hat (017b7) ~ Normal(mean=Variable (53966), variance=Variable (e94e0))\n",
+      "Variable s (931ba) = GluonFunctionEvaluation(hybridlambda0_input_0=Variable s_hat (017b7))\n",
+      "Variable mu (eddd1) ~ Normal(mean=Variable (4d278), variance=Variable (a177f))\n",
+      "Variable Y (ec67c) ~ Normal(mean=Variable mu (eddd1), variance=Variable s (931ba))\n"
      ]
     }
    ],
@@ -345,9 +345,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Posterior (4cdab)\n",
-      "Variable s_hat (084af) ~ Normal(mean=Variable (7bf00), variance=Variable (aa526))\n",
-      "Variable mu (9da62) ~ Normal(mean=Variable (3e607), variance=Variable (a2372))\n"
+      "Posterior (39e0f)\n",
+      "Variable s_hat (017b7) ~ Normal(mean=Variable (85fbe), variance=Variable (2b20f))\n",
+      "Variable mu (eddd1) ~ Normal(mean=Variable (b8c42), variance=Variable (28aae))\n"
      ]
     }
    ],
@@ -391,8 +391,8 @@
     "from mxfusion.inference import StochasticVariationalInference\n",
     "\n",
     "infr = GradBasedInference(inference_algorithm=StochasticVariationalInference(\n",
-    "    model=m, posterior=q, num_samples=10, observed=[m.Y]), logger=Logger())\n",
-    "infr.run(Y=mx.nd.array(data, dtype='float64'), learning_rate=0.1)"
+    "    model=m, posterior=q, num_samples=10, observed=[m.Y]))\n",
+    "infr.run(Y=mx.nd.array(data, dtype='float64'), learning_rate=0.1, verbose=True)"
    ]
   },
   {

--- a/examples/notebooks/getting_started.ipynb
+++ b/examples/notebooks/getting_started.ipynb
@@ -202,7 +202,7 @@
     }
    ],
    "source": [
-    "from mxfusion.inference import GradBasedInference, MAP, Logger\n",
+    "from mxfusion.inference import GradBasedInference, MAP\n",
     "import mxnet as mx\n",
     "\n",
     "infr = GradBasedInference(inference_algorithm=MAP(model=m, observed=[m.Y]))\n",
@@ -440,7 +440,7 @@
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-mxfusion-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/examples/notebooks/getting_started.ipynb
+++ b/examples/notebooks/getting_started.ipynb
@@ -90,12 +90,14 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAX4AAAD8CAYAAABw1c+bAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAEB5JREFUeJzt3X+MZWV9x/H3p4BaEQu6I8qPdWxLaJEIksmqJTVYlMJCoG1sy6a1VGlWDbbamNRVE23sPzRW7Q+MdAtbtFI0RbGkuyBbNUETQQdcYBEQSlcZl7KLKEixMavf/jFnk+lwZ3d6z525u/O8X8nNPec5zz3P92R3P3vmmXPOTVUhSWrHz4y7AEnS8jL4JakxBr8kNcbgl6TGGPyS1BiDX5IaY/BLUmMMfklqjMEvSY05dNwFDLJq1aqanJwcdxmSdNC47bbbHq2qicX0PSCDf3Jykunp6XGXIUkHjSTfXmxfp3okqTEGvyQ1xuCXpMYY/JLUGINfkhpj8EtSYwx+SWqMwS9JjTH4JakxB+Sdu9KBanLD5rGMu+PSc8cyrlYmz/glqTH7PeNPsgk4D9hVVSd3bZ8GTuy6HAn8oKpOHfDZHcAPgZ8Ae6pqakR1S5KGtJipnquAy4BP7G2oqt/du5zkQ8Dj+/j8a6rq0WELlCSN1n6Dv6puTjI5aFuSAL8D/Npoy5IkLZW+c/y/CjxSVfcvsL2Am5LclmT9vnaUZH2S6STTu3fv7lmWJGkhfYN/HXDNPrafXlWnAecAlyR59UIdq2pjVU1V1dTExKK+S0CSNIShgz/JocBvAZ9eqE9V7ezedwHXAWuGHU+SNBp9zvhfC9xbVTODNiY5PMkRe5eBs4DtPcaTJI3AfoM/yTXAV4ETk8wkubjbdCHzpnmSHJNkS7d6NPCVJHcAXwM2V9WNoytdkjSMxVzVs26B9j8c0LYTWNstPwic0rM+SdKI+cgGHZTG9egEaSXwkQ2S1BiDX5IaY/BLUmMMfklqjMEvSY0x+CWpMQa/JDXG4Jekxhj8ktQYg1+SGmPwS1JjfFaPdBAY57OJdlx67tjG1tLwjF+SGmPwS1JjDH5JaozBL0mNMfglqTEGvyQ1xuCXpMbsN/iTbEqyK8n2OW1/nuS7SbZ1r7ULfPbsJPcleSDJhlEWLkkazmLO+K8Czh7Q/pGqOrV7bZm/MckhwEeBc4CTgHVJTupTrCSpv/0Gf1XdDDw2xL7XAA9U1YNV9WPgU8AFQ+xHkjRCfeb435bkzm4q6KgB248FHpqzPtO1DZRkfZLpJNO7d+/uUZYkaV+GDf6PAb8AnAo8DHxoQJ8MaKuFdlhVG6tqqqqmJiYmhixLkrQ/QwV/VT1SVT+pqp8C/8DstM58M8Dxc9aPA3YOM54kaXSGCv4kL5qz+pvA9gHdvg6ckOQlSZ4BXAhcP8x4kqTR2e9jmZNcA5wBrEoyA7wfOCPJqcxO3ewA3tz1PQa4oqrWVtWeJG8DPg8cAmyqqruX5CgkSYu23+CvqnUDmq9coO9OYO2c9S3A0y71lCSNj3fuSlJjDH5JaozBL0mNMfglqTEGvyQ1xuCXpMYY/JLUGINfkhpj8EtSYwx+SWqMwS9JjTH4JakxBr8kNcbgl6TGGPyS1BiDX5IaY/BLUmP2+w1c0kImN2wedwmShuAZvyQ1Zr/Bn2RTkl1Jts9p+2CSe5PcmeS6JEcu8NkdSe5Ksi3J9CgLlyQNZzFn/FcBZ89r2wqcXFUvA74FvHsfn39NVZ1aVVPDlShJGqX9Bn9V3Qw8Nq/tpqra063eAhy3BLVJkpbAKOb43wTcsMC2Am5KcluS9SMYS5LUU6+repK8F9gDXL1Al9OrameSFwBbk9zb/QQxaF/rgfUAq1ev7lOWJGkfhj7jT3IRcB7we1VVg/pU1c7ufRdwHbBmof1V1caqmqqqqYmJiWHLkiTtx1DBn+Rs4F3A+VX11AJ9Dk9yxN5l4Cxg+6C+kqTls5jLOa8BvgqcmGQmycXAZcARzE7fbEtyedf3mCRbuo8eDXwlyR3A14DNVXXjkhyFJGnR9jvHX1XrBjRfuUDfncDabvlB4JRe1UmSRs47dyWpMQa/JDXG4Jekxhj8ktQYg1+SGmPwS1JjDH5JaozBL0mNMfglqTEGvyQ1xuCXpMYY/JLUmF5fxCJp5ZvcsHks4+649NyxjNsCz/glqTEGvyQ1xuCXpMYY/JLUGINfkhpj8EtSYwx+SWrMooI/yaYku5Jsn9P2vCRbk9zfvR+1wGcv6vrcn+SiURUuSRrOYs/4rwLOnte2AfhCVZ0AfKFb/z+SPA94P/AKYA3w/oX+g5AkLY9FBX9V3Qw8Nq/5AuDj3fLHgd8Y8NFfB7ZW1WNV9X1gK0//D0SStIz6zPEfXVUPA3TvLxjQ51jgoTnrM12bJGlMlvqXuxnQVgM7JuuTTCeZ3r179xKXJUnt6hP8jyR5EUD3vmtAnxng+DnrxwE7B+2sqjZW1VRVTU1MTPQoS5K0L32C/3pg71U6FwH/OqDP54GzkhzV/VL3rK5NkjQmi72c8xrgq8CJSWaSXAxcCrwuyf3A67p1kkwluQKgqh4D/gL4evf6QNcmSRqTRT2Pv6rWLbDpzAF9p4E/mrO+Cdg0VHWSpJHzzl1JaozBL0mNMfglqTEGvyQ1xuCXpMYY/JLUGINfkhpj8EtSYwx+SWqMwS9JjTH4JakxBr8kNcbgl6TGGPyS1BiDX5IaY/BLUmMMfklqjMEvSY0x+CWpMQa/JDVm6OBPcmKSbXNeTyR5x7w+ZyR5fE6f9/UvWZLUx6HDfrCq7gNOBUhyCPBd4LoBXb9cVecNO44kabRGNdVzJvAfVfXtEe1PkrRERhX8FwLXLLDtVUnuSHJDkpeOaDxJ0pB6B3+SZwDnA/8yYPPtwIur6hTg74DP7WM/65NMJ5nevXt337IkSQsYxRn/OcDtVfXI/A1V9URVPdktbwEOS7Jq0E6qamNVTVXV1MTExAjKkiQNMorgX8cC0zxJXpgk3fKabrzvjWBMSdKQhr6qByDJs4HXAW+e0/YWgKq6HHg98NYke4AfARdWVfUZU5LUT6/gr6qngOfPa7t8zvJlwGV9xpAkjVav4NeBYXLD5nGXII3cOP9e77j03LGNvRx8ZIMkNcbgl6TGGPyS1BiDX5IaY/BLUmMMfklqjMEvSY0x+CWpMQa/JDXG4Jekxhj8ktQYg1+SGmPwS1JjDH5JaozBL0mNMfglqTEGvyQ1xuCXpMYY/JLUmN7Bn2RHkruSbEsyPWB7kvxtkgeS3JnktL5jSpKGN6ovW39NVT26wLZzgBO61yuAj3XvkqQxWI6pnguAT9SsW4Ajk7xoGcaVJA0wijP+Am5KUsDfV9XGeduPBR6asz7TtT08t1OS9cB6gNWrV4+grOU1uWHzuEuQNCLj+ve849Jzl2WcUZzxn15VpzE7pXNJklfP254Bn6mnNVRtrKqpqpqamJgYQVmSpEF6B39V7ezedwHXAWvmdZkBjp+zfhyws++4kqTh9Ar+JIcnOWLvMnAWsH1et+uBP+iu7nkl8HhVPYwkaSz6zvEfDVyXZO++/rmqbkzyFoCquhzYAqwFHgCeAt7Yc0xJUg+9gr+qHgROGdB++ZzlAi7pM44kaXS8c1eSGmPwS1JjDH5JaozBL0mNMfglqTEGvyQ1xuCXpMYY/JLUGINfkhpj8EtSYwx+SWqMwS9JjTH4JakxBr8kNcbgl6TGGPyS1BiDX5IaY/BLUmMMfklqzNDBn+T4JF9Kck+Su5O8fUCfM5I8nmRb93pfv3IlSX31+bL1PcA7q+r2JEcAtyXZWlXfnNfvy1V1Xo9xJEkjNPQZf1U9XFW3d8s/BO4Bjh1VYZKkpTGSOf4kk8DLgVsHbH5VkjuS3JDkpaMYT5I0vD5TPQAkeQ7wGeAdVfXEvM23Ay+uqieTrAU+B5ywwH7WA+sBVq9e3bcsSdICep3xJzmM2dC/uqo+O397VT1RVU92y1uAw5KsGrSvqtpYVVNVNTUxMdGnLEnSPvS5qifAlcA9VfXhBfq8sOtHkjXdeN8bdkxJUn99pnpOB94A3JVkW9f2HmA1QFVdDrweeGuSPcCPgAurqnqMKUnqaejgr6qvANlPn8uAy4YdQ5I0et65K0mNMfglqTEGvyQ1xuCXpMYY/JLUGINfkhpj8EtSYwx+SWqMwS9JjTH4JakxBr8kNcbgl6TG9P4ilgPN5IbN4y5Bkg5onvFLUmMMfklqjMEvSY0x+CWpMQa/JDXG4Jekxhj8ktSYXsGf5Owk9yV5IMmGAdufmeTT3fZbk0z2GU+S1N/QwZ/kEOCjwDnAScC6JCfN63Yx8P2q+kXgI8BfDjueJGk0+pzxrwEeqKoHq+rHwKeAC+b1uQD4eLd8LXBmkvQYU5LUU5/gPxZ4aM76TNc2sE9V7QEeB57fY0xJUk99ntUz6My9hugz2zFZD6zvVp9Mcl+P2kZpFfDouItYQiv9+GDlH+NKPz5Y+ce4Cng0/SbDX7zYjn2CfwY4fs76ccDOBfrMJDkU+DngsUE7q6qNwMYe9SyJJNNVNTXuOpbKSj8+WPnHuNKPD1b+MS738fWZ6vk6cEKSlyR5BnAhcP28PtcDF3XLrwe+WFUDz/glSctj6DP+qtqT5G3A54FDgE1VdXeSDwDTVXU9cCXwT0keYPZM/8JRFC1JGl6v5/FX1RZgy7y2981Z/h/gt/uMcQA44KafRmylHx+s/GNc6ccHK/8Yl/X44syLJLXFRzZIUmMM/kVI8sEk9ya5M8l1SY4cd02jsL9HbhzMkhyf5EtJ7klyd5K3j7umpZDkkCTfSPJv465lKSQ5Msm13b+/e5K8atw1jVqSP+3+jm5Pck2SZy31mAb/4mwFTq6qlwHfAt495np6W+QjNw5me4B3VtUvA68ELllhx7fX24F7xl3EEvob4Maq+iXgFFbYsSY5FvgTYKqqTmb2QpklvwjG4F+Eqrqpu/MY4BZm71k42C3mkRsHrap6uKpu75Z/yGxgzL+z/KCW5DjgXOCKcdeyFJI8F3g1s1cHUlU/rqofjLeqJXEo8LPdvU7P5un3Q42cwf//9ybghnEXMQKLeeTGitA9FfblwK3jrWTk/hr4M+Cn4y5kifw8sBv4x24664okh4+7qFGqqu8CfwV8B3gYeLyqblrqcQ3+TpJ/7+bY5r8umNPnvcxOIVw9vkpHZtGP0ziYJXkO8BngHVX1xLjrGZUk5wG7quq2cdeyhA4FTgM+VlUvB/4bWGm/izqK2Z+0XwIcAxye5PeXetxe1/GvJFX12n1tT3IRcB5w5gq5+3gxj9w4qCU5jNnQv7qqPjvuekbsdOD8JGuBZwHPTfLJqlry0FhGM8BMVe39Se1aVljwA68F/rOqdgMk+SzwK8Anl3JQz/gXIcnZwLuA86vqqXHXMyKLeeTGQat7/PeVwD1V9eFx1zNqVfXuqjquqiaZ/bP74goLfarqv4CHkpzYNZ0JfHOMJS2F7wCvTPLs7u/smSzDL7A941+cy4BnAlu7rxO4pareMt6S+lnokRtjLmuUTgfeANyVZFvX9p7ubnMdPP4YuLo7OXkQeOOY6xmpqro1ybXA7cxOI3+DZbiL1zt3JakxTvVIUmMMfklqjMEvSY0x+CWpMQa/JDXG4Jekxhj8ktQYg1+SGvO/DZ47ZQlqyawAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAX4AAAD8CAYAAABw1c+bAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4wLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvqOYd8AAAEAFJREFUeJzt3X+sX3V9x/Hna4A6kQnaO5Qf9ZKNsCARJDdVpzM4kJVCYFvcRrM5VJaqwU0XE1M10cX9w+LU/cDIOujQydAMrSNrQTo1QRNBb7FA+SWMVWlBWkRB1MVU3/vjniZ31+9tr9/zvf229/N8JN/ccz7n8z2f90lvX/fczz3nfFNVSJLa8UvjLkCSdGAZ/JLUGINfkhpj8EtSYwx+SWqMwS9JjTH4JakxBr8kNcbgl6TGHD7uAgZZtmxZTU5OjrsMSTpkbNmy5fGqmlhI34My+CcnJ5menh53GZJ0yEjyrYX2dapHkhpj8EtSYwx+SWqMwS9JjTH4JakxBr8kNcbgl6TGGPyS1BiDX5Iac1DeuSsdrCbXbhzLuNsvP38s42pp8oxfkhqz3zP+JOuBC4BdVXVa1/Zp4JSuy9HA96vqjAHv3Q78APgpsKeqpkZUtyRpSAuZ6rkGuAL4xN6GqvqjvctJPgQ8uY/3v6aqHh+2QEnSaO03+KvqliSTg7YlCfCHwG+PtixJ0mLpO8f/W8BjVfXAPNsLuDnJliRr9rWjJGuSTCeZ3r17d8+yJEnz6Rv8q4Hr9rH9VVV1JnAecFmSV8/XsarWVdVUVU1NTCzoswQkSUMYOviTHA78PvDp+fpU1c7u6y5gA7Bi2PEkSaPR54z/HOC+qtoxaGOSI5MctXcZOBfY1mM8SdII7Df4k1wHfBU4JcmOJJd2my5mzjRPkuOSbOpWjwW+kuQO4GvAxqq6aXSlS5KGsZCrelbP0/6GAW2PAKu65YeA03vWJ0kaMR/ZoEPSuB6dIC0FPrJBkhpj8EtSYwx+SWqMwS9JjTH4JakxBr8kNcbgl6TGGPyS1BiDX5IaY/BLUmMMfklqjM/qkQ4B43w20fbLzx/b2FocnvFLUmMMfklqjMEvSY0x+CWpMQa/JDXG4Jekxhj8ktSY/QZ/kvVJdiXZNqvtr5LsTLK1e62a570rk9yf5MEka0dZuCRpOAs5478GWDmg/SNVdUb32jR3Y5LDgI8C5wGnAquTnNqnWElSf/sN/qq6BXhiiH2vAB6sqoeq6ifAp4CLhtiPJGmE+szxvy3Jnd1U0DEDth8PPDxrfUfXNlCSNUmmk0zv3r27R1mSpH0ZNvg/BvwacAbwKPChvoVU1bqqmqqqqYmJib67kyTNY6jgr6rHquqnVfUz4J+ZmdaZaydw4qz1E7o2SdIYDRX8SV44a/X3gG0Dun0dODnJSUmeAVwM3DDMeJKk0dnvY5mTXAecBSxLsgN4P3BWkjOAArYDb+76HgdcVVWrqmpPkrcBnwcOA9ZX1d2LchSSpAXbb/BX1eoBzVfP0/cRYNWs9U3Az13qKUkaH+/claTGGPyS1BiDX5IaY/BLUmMMfklqjMEvSY0x+CWpMQa/JDXG4Jekxhj8ktQYg1+SGmPwS1JjDH5JaozBL0mNMfglqTEGvyQ1xuCXpMbs9xO4pPlMrt047hIkDcEzfklqzH6DP8n6JLuSbJvV9sEk9yW5M8mGJEfP897tSe5KsjXJ9CgLlyQNZyFn/NcAK+e0bQZOq6qXAN8E3r2P97+mqs6oqqnhSpQkjdJ+g7+qbgGemNN2c1Xt6VZvBU5YhNokSYtgFHP8bwJunGdbATcn2ZJkzQjGkiT11OuqniTvBfYA187T5VVVtTPJrwKbk9zX/QYxaF9rgDUAy5cv71OWJGkfhj7jT/IG4ALgj6uqBvWpqp3d113ABmDFfPurqnVVNVVVUxMTE8OWJUnaj6GCP8lK4F3AhVX1o3n6HJnkqL3LwLnAtkF9JUkHzkIu57wO+CpwSpIdSS4FrgCOYmb6ZmuSK7u+xyXZ1L31WOArSe4AvgZsrKqbFuUoJEkLtt85/qpaPaD56nn6PgKs6pYfAk7vVZ0kaeS8c1eSGmPwS1JjDH5JaozBL0mNMfglqTEGvyQ1xuCXpMYY/JLUGINfkhpj8EtSYwx+SWqMwS9Jjen1QSySlr7JtRvHMu72y88fy7gt8Ixfkhpj8EtSYwx+SWqMwS9JjTH4JakxBr8kNcbgl6TGLCj4k6xPsivJtlltz0uyOckD3ddj5nnvJV2fB5JcMqrCJUnDWegZ/zXAyjlta4EvVNXJwBe69f8nyfOA9wMvA1YA75/vB4Qk6cBYUPBX1S3AE3OaLwI+3i1/HPjdAW/9HWBzVT1RVd8DNvPzP0AkSQdQnzn+Y6vq0W75O8CxA/ocDzw8a31H1yZJGpOR/HG3qgqoPvtIsibJdJLp3bt3j6IsSdIAfYL/sSQvBOi+7hrQZydw4qz1E7q2n1NV66pqqqqmJiYmepQlSdqXPsF/A7D3Kp1LgP8Y0OfzwLlJjun+qHtu1yZJGpOFXs55HfBV4JQkO5JcClwOvDbJA8A53TpJppJcBVBVTwB/DXy9e32ga5MkjcmCnsdfVavn2XT2gL7TwJ/NWl8PrB+qOknSyHnnriQ1xuCXpMYY/JLUGINfkhpj8EtSYwx+SWqMwS9JjTH4JakxBr8kNcbgl6TGGPyS1BiDX5IaY/BLUmMMfklqjMEvSY0x+CWpMQa/JDXG4Jekxhj8ktQYg1+SGjN08Cc5JcnWWa+nkrxjTp+zkjw5q8/7+pcsSerj8GHfWFX3A2cAJDkM2AlsGND1y1V1wbDjSJJGa1RTPWcD/11V3xrR/iRJi2RUwX8xcN08216R5I4kNyZ58YjGkyQNqXfwJ3kGcCHw7wM23w68qKpOB/4R+Nw+9rMmyXSS6d27d/ctS5I0j1Gc8Z8H3F5Vj83dUFVPVdXT3fIm4IgkywbtpKrWVdVUVU1NTEyMoCxJ0iCjCP7VzDPNk+QFSdItr+jG++4IxpQkDWnoq3oAkhwJvBZ486y2twBU1ZXA64C3JtkD/Bi4uKqqz5iSpH56BX9V/RB4/py2K2ctXwFc0WcMSdJo9Qp+HRwm124cdwnSyI3z+3r75eePbewDwUc2SFJjDH5JaozBL0mNMfglqTEGvyQ1xuCXpMYY/JLUGINfkhpj8EtSYwx+SWqMwS9JjTH4JakxBr8kNcbgl6TGGPyS1BiDX5IaY/BLUmMMfklqjMEvSY3pHfxJtie5K8nWJNMDtifJPyR5MMmdSc7sO6YkaXij+rD111TV4/NsOw84uXu9DPhY91WSNAYHYqrnIuATNeNW4OgkLzwA40qSBhjFGX8BNycp4J+qat2c7ccDD89a39G1PTq7U5I1wBqA5cuXj6CsA2ty7cZxlyBpRMb1/3n75ecfkHFGccb/qqo6k5kpncuSvHqYnVTVuqqaqqqpiYmJEZQlSRqkd/BX1c7u6y5gA7BiTpedwImz1k/o2iRJY9Ar+JMcmeSovcvAucC2Od1uAP60u7rn5cCTVfUokqSx6DvHfyywIcneff1bVd2U5C0AVXUlsAlYBTwI/Ah4Y88xJUk99Ar+qnoIOH1A+5Wzlgu4rM84kqTR8c5dSWqMwS9JjTH4JakxBr8kNcbgl6TGGPyS1BiDX5IaY/BLUmMMfklqjMEvSY0x+CWpMQa/JDXG4Jekxhj8ktQYg1+SGmPwS1JjDH5JaozBL0mNMfglqTFDB3+SE5N8Kck9Se5O8vYBfc5K8mSSrd3rff3KlST11efD1vcA76yq25McBWxJsrmq7pnT78tVdUGPcSRJIzT0GX9VPVpVt3fLPwDuBY4fVWGSpMUxkjn+JJPAS4HbBmx+RZI7ktyY5MWjGE+SNLw+Uz0AJHkO8BngHVX11JzNtwMvqqqnk6wCPgecPM9+1gBrAJYvX963LEnSPHqd8Sc5gpnQv7aqPjt3e1U9VVVPd8ubgCOSLBu0r6paV1VTVTU1MTHRpyxJ0j70uaonwNXAvVX14Xn6vKDrR5IV3XjfHXZMSVJ/faZ6Xgm8Hrgrydau7T3AcoCquhJ4HfDWJHuAHwMXV1X1GFOS1NPQwV9VXwGynz5XAFcMO4YkafS8c1eSGmPwS1JjDH5JaozBL0mNMfglqTEGvyQ1xuCXpMYY/JLUGINfkhpj8EtSYwx+SWqMwS9Jjen9QSwHm8m1G8ddgiQd1Dzjl6TGGPyS1BiDX5IaY/BLUmMMfklqjMEvSY0x+CWpMb2CP8nKJPcneTDJ2gHbn5nk093225JM9hlPktTf0MGf5DDgo8B5wKnA6iSnzul2KfC9qvp14CPA3ww7niRpNPqc8a8AHqyqh6rqJ8CngIvm9LkI+Hi3fD1wdpL0GFOS1FOf4D8eeHjW+o6ubWCfqtoDPAk8v8eYkqSeDppn9SRZA6zpVp9Ocv8465llGfD4uItYREv9+GDpH+NSPz5Y+se4DHg8/SbDX7TQjn2Cfydw4qz1E7q2QX12JDkceC7w3UE7q6p1wLoe9SyKJNNVNTXuOhbLUj8+WPrHuNSPD5b+MR7o4+sz1fN14OQkJyV5BnAxcMOcPjcAl3TLrwO+WFXVY0xJUk9Dn/FX1Z4kbwM+DxwGrK+qu5N8AJiuqhuAq4F/TfIg8AQzPxwkSWPUa46/qjYBm+a0vW/W8v8Cf9BnjIPAQTf9NGJL/fhg6R/jUj8+WPrHeECPL868SFJbfGSDJDXG4F+AJB9Mcl+SO5NsSHL0uGsahf09cuNQluTEJF9Kck+Su5O8fdw1LYYkhyX5RpL/HHctiyHJ0Umu7/7/3ZvkFeOuadSS/GX3PbotyXVJnrXYYxr8C7MZOK2qXgJ8E3j3mOvpbYGP3DiU7QHeWVWnAi8HLltix7fX24F7x13EIvp74Kaq+g3gdJbYsSY5HvgLYKqqTmPmQplFvwjG4F+Aqrq5u/MY4FZm7lk41C3kkRuHrKp6tKpu75Z/wExgzL2z/JCW5ATgfOCqcdeyGJI8F3g1M1cHUlU/qarvj7eqRXE48MvdvU7PBh5Z7AEN/l/cm4Abx13ECCzkkRtLQvdU2JcCt423kpH7O+BdwM/GXcgiOQnYDfxLN511VZIjx13UKFXVTuBvgW8DjwJPVtXNiz2uwd9J8l/dHNvc10Wz+ryXmSmEa8dXqX4RSZ4DfAZ4R1U9Ne56RiXJBcCuqtoy7loW0eHAmcDHquqlwA+Bpfa3qGOY+U37JOA44Mgkf7LY4x40z+oZt6o6Z1/bk7wBuAA4e4ncfbyQR24c0pIcwUzoX1tVnx13PSP2SuDCJKuAZwG/kuSTVbXooXEA7QB2VNXe39SuZ4kFP3AO8D9VtRsgyWeB3wQ+uZiDesa/AElWMvMr9YVV9aNx1zMiC3nkxiGre/z31cC9VfXhcdczalX17qo6oaommfm3++ISC32q6jvAw0lO6ZrOBu4ZY0mL4dvAy5M8u/uePZsD8Adsz/gX5grgmcDm7uMEbq2qt4y3pH7me+TGmMsapVcCrwfuSrK1a3tPd7e5Dh1/DlzbnZw8BLxxzPWMVFXdluR64HZmppG/wQG4i9c7dyWpMU71SFJjDH5JaozBL0mNMfglqTEGvyQ1xuCXpMYY/JLUGINfkhrzf78cN2JoOpv5AAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
      },
-     "metadata": {},
+     "metadata": {
+      "needs_background": "light"
+     },
      "output_type": "display_data"
     }
    ],
@@ -157,7 +159,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Y ~ Normal(mean=mu, variance=s)\n"
+      "Model (006af)\n",
+      "Variable Y (407ed) ~ Normal(mean=Variable mu (ae180), variance=Variable s (24199))\n"
      ]
     }
    ],
@@ -185,25 +188,26 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Iteration 201 loss: 226.00307424753382\n",
-      "Iteration 401 loss: 223.62512496838366\n",
-      "Iteration 601 loss: 223.23108001422028\n",
-      "Iteration 801 loss: 223.16242835266598\n",
-      "Iteration 1001 loss: 223.15215875874755\n",
-      "Iteration 1201 loss: 223.15098355232075\n",
-      "Iteration 1401 loss: 223.15088846215527\n",
-      "Iteration 1601 loss: 223.15088333213185\n",
-      "Iteration 1801 loss: 223.15088315658113\n",
-      "Iteration 2000 loss: 223.15088315295884"
+      "Iteration 200 loss: 226.030\t\t\t\t\n",
+      "Iteration 400 loss: 223.629\t\t\t\t\n",
+      "Iteration 600 loss: 223.232\t\t\t\t\n",
+      "Iteration 800 loss: 223.163\t\t\t\t\n",
+      "Iteration 1000 loss: 223.152\t\t\t\t\n",
+      "Iteration 1200 loss: 223.151\t\t\t\t\n",
+      "Iteration 1400 loss: 223.151\t\t\t\t\n",
+      "Iteration 1600 loss: 223.151\t\t\t\t\n",
+      "Iteration 1800 loss: 223.151\t\t\t\t\n",
+      "Iteration 2000 loss: 223.151\t\t\t\t\n"
      ]
     }
    ],
    "source": [
-    "from mxfusion.inference import GradBasedInference, MAP\n",
+    "from mxfusion.inference import GradBasedInference, MAP, Logger\n",
     "import mxnet as mx\n",
     "\n",
     "infr = GradBasedInference(inference_algorithm=MAP(model=m, observed=[m.Y]))\n",
-    "infr.run(Y=mx.nd.array(data, dtype='float64'), learning_rate=0.1, max_iter=2000, verbose=True)"
+    "with Logger() as ll:\n",
+    "    infr.run(Y=mx.nd.array(data, dtype='float64'), learning_rate=0.1, max_iter=2000, logger=ll)"
    ]
   },
   {
@@ -311,10 +315,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "s_hat ~ Normal(mean=Variable(66591), variance=Variable(582f6))\n",
-      "s = GluonFunctionEvaluation(hybridlambda0_input_0=s_hat)\n",
-      "mu ~ Normal(mean=Variable(230f5), variance=Variable(e5c1f))\n",
-      "Y ~ Normal(mean=mu, variance=s)\n"
+      "Model (4d361)\n",
+      "Variable s_hat (0f46e) ~ Normal(mean=Variable (57766), variance=Variable (89a6a))\n",
+      "Variable s (e08eb) = GluonFunctionEvaluation(hybridlambda0_input_0=Variable s_hat (0f46e))\n",
+      "Variable mu (39398) ~ Normal(mean=Variable (bba5c), variance=Variable (cf3b1))\n",
+      "Variable Y (6dc0c) ~ Normal(mean=Variable mu (39398), variance=Variable s (e08eb))\n"
      ]
     }
    ],
@@ -341,8 +346,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "s_hat ~ Normal(mean=Variable(987b5), variance=Variable(bf47c))\n",
-      "mu ~ Normal(mean=Variable(9c88b), variance=Variable(3ce74))\n"
+      "Posterior (01a55)\n",
+      "Variable s_hat (0f46e) ~ Normal(mean=Variable (20a5e), variance=Variable (6f639))\n",
+      "Variable mu (39398) ~ Normal(mean=Variable (7bf67), variance=Variable (31b9f))\n"
      ]
     }
    ],
@@ -369,16 +375,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Iteration 201 loss: 234.52798823187217\n",
-      "Iteration 401 loss: 231.30663180752714\n",
-      "Iteration 601 loss: 230.14185436095775\n",
-      "Iteration 801 loss: 230.02993763459781\n",
-      "Iteration 1001 loss: 229.6937452192292\n",
-      "Iteration 1201 loss: 229.72574317072662\n",
-      "Iteration 1401 loss: 229.65264175269712\n",
-      "Iteration 1601 loss: 229.67285188868293\n",
-      "Iteration 1801 loss: 229.52906307607037\n",
-      "Iteration 2000 loss: 229.64091981034755"
+      "Iteration 200 loss: 235.140\t\t\t\t\n",
+      "Iteration 400 loss: 231.011\t\t\t\t\n",
+      "Iteration 600 loss: 229.947\t\t\t\t\n",
+      "Iteration 800 loss: 229.648\t\t\t\t\n",
+      "Iteration 1000 loss: 229.859\t\t\t\t\n",
+      "Iteration 1200 loss: 229.752\t\t\t\t\n",
+      "Iteration 1400 loss: 229.651\t\t\t\t\n",
+      "Iteration 1600 loss: 229.705\t\t\t\t\n",
+      "Iteration 1800 loss: 229.634\t\t\t\t\n",
+      "Iteration 2000 loss: 229.641\t\t\t\t\n"
      ]
     }
    ],
@@ -387,7 +393,8 @@
     "\n",
     "infr = GradBasedInference(inference_algorithm=StochasticVariationalInference(\n",
     "    model=m, posterior=q, num_samples=10, observed=[m.Y]))\n",
-    "infr.run(Y=mx.nd.array(data, dtype='float64'), learning_rate=0.1, verbose=True)"
+    "with Logger() as ll:\n",
+    "    infr.run(Y=mx.nd.array(data, dtype='float64'), learning_rate=0.1, logger=ll)"
    ]
   },
   {
@@ -435,7 +442,7 @@
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-mxfusion-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -447,7 +454,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,

--- a/mxfusion/inference/__init__.py
+++ b/mxfusion/inference/__init__.py
@@ -32,19 +32,20 @@ Submodules
     meanfield
     minibatch_loop
     variational
+    logger
 """
 
-
-from .map import MAP
 from .batch_loop import BatchInferenceLoop
-from .inference import Inference, TransferInference
-from .minibatch_loop import MinibatchInferenceLoop
-from .meanfield import create_Gaussian_meanfield
+from .expectation import ExpectationAlgorithm, ExpectationScoreFunctionAlgorithm
 from .forward_sampling import ForwardSampling, VariationalPosteriorForwardSampling, ForwardSamplingAlgorithm
 from .grad_based_inference import GradBasedInference, GradTransferInference
-from .variational import StochasticVariationalInference
+from .inference import Inference, TransferInference
 from .inference_parameters import InferenceParameters
-from .score_function import ScoreFunctionInference, ScoreFunctionRBInference
-from .expectation import ExpectationAlgorithm, ExpectationScoreFunctionAlgorithm
-from .prediction import ModulePredictionAlgorithm
+from .logger import Logger
+from .map import MAP
+from .meanfield import create_Gaussian_meanfield
+from .minibatch_loop import MinibatchInferenceLoop
 from .pilco_alg import PILCOAlgorithm
+from .prediction import ModulePredictionAlgorithm
+from .score_function import ScoreFunctionInference, ScoreFunctionRBInference
+from .variational import StochasticVariationalInference

--- a/mxfusion/inference/batch_loop.py
+++ b/mxfusion/inference/batch_loop.py
@@ -44,6 +44,9 @@ class BatchInferenceLoop(GradLoop):
         :param logger: The logger to send logs to
         :type logger: :class:`inference.Logger`
         """
+        if logger:
+            logger.open()
+
         trainer = mx.gluon.Trainer(param_dict,
                                    optimizer=optimizer,
                                    optimizer_params={'learning_rate': learning_rate})
@@ -60,4 +63,4 @@ class BatchInferenceLoop(GradLoop):
         infr_executor(mx.nd.zeros(1, ctx=ctx), *data)
 
         if logger:
-            logger.flush()
+            logger.close()

--- a/mxfusion/inference/batch_loop.py
+++ b/mxfusion/inference/batch_loop.py
@@ -23,7 +23,7 @@ class BatchInferenceLoop(GradLoop):
     """
 
     def run(self, infr_executor, data, param_dict, ctx, optimizer='adam',
-            learning_rate=1e-3, max_iter=1000, n_prints=10, logger=None):
+            learning_rate=1e-3, max_iter=1000, n_prints=10, verbose=False, logger=None):
         """
         :param infr_executor: The MXNet function that computes the training objective.
         :type infr_executor: MXNet Gluon Block
@@ -41,6 +41,8 @@ class BatchInferenceLoop(GradLoop):
         :type n_prints: int
         :param max_iter: the maximum number of iterations of gradient optimization
         :type max_iter: int
+        :param verbose: whether to print per-iteration messages.
+        :type verbose: boolean
         :param logger: The logger to send logs to
         :type logger: :class:`inference.Logger`
         """
@@ -57,7 +59,7 @@ class BatchInferenceLoop(GradLoop):
                 loss_for_gradient.backward()
 
             if logger:
-                logger.log("loss", loss.asscalar(), i, newline=not i % iter_step)
+                logger.log("loss", loss.asscalar(), i, newline=not i % iter_step, verbose=verbose)
 
             trainer.step(batch_size=1, ignore_stale_grad=True)
         infr_executor(mx.nd.zeros(1, ctx=ctx), *data)

--- a/mxfusion/inference/grad_based_inference.py
+++ b/mxfusion/inference/grad_based_inference.py
@@ -13,10 +13,10 @@
 # ==============================================================================
 
 
-from .inference import Inference
 from .batch_loop import BatchInferenceLoop
-from ..util.inference import discover_shape_constants, init_outcomes
+from .inference import Inference
 from .minibatch_loop import MinibatchInferenceLoop
+from ..util.inference import discover_shape_constants, init_outcomes
 
 
 class GradBasedInference(Inference):
@@ -38,6 +38,7 @@ class GradBasedInference(Inference):
     :param context: The MXNet context
     :type context: {mxnet.cpu or mxnet.gpu}
     """
+
     def __init__(self, inference_algorithm, grad_loop=None, constants=None,
                  hybridize=False, dtype=None, context=None):
         if grad_loop is None:
@@ -65,7 +66,7 @@ class GradBasedInference(Inference):
         return infr
 
     def run(self, optimizer='adam', learning_rate=1e-3, max_iter=2000,
-            verbose=False, **kwargs):
+            logger=None, **kwargs):
         """
         Run the inference method.
 
@@ -75,8 +76,8 @@ class GradBasedInference(Inference):
         :type learning_rate: float
         :param max_iter: the maximum number of iterations of gradient optimization
         :type max_iter: int
-        :param verbose: whether to print per-iteration messages.
-        :type verbose: boolean
+        :param logger: The logger to send logs to
+        :type logger: :class:`inference.Logger`
         :param kwargs: The keyword arguments specify the data for inferences. The key of each argument is the name of
         the corresponding variable in model definition and the value of the argument is the data in numpy array format.
         """
@@ -95,13 +96,14 @@ class GradBasedInference(Inference):
             return self._grad_loop.run(
                 infr_executor=infr, data=data, param_dict=self.params.param_dict,
                 ctx=self.mxnet_context, optimizer=optimizer,
-                learning_rate=learning_rate, max_iter=max_iter, verbose=verbose,
-                update_shape_constants=update_shape_constants)
+                learning_rate=learning_rate, max_iter=max_iter,
+                update_shape_constants=update_shape_constants, logger=logger)
         else:
             return self._grad_loop.run(
                 infr_executor=infr, data=data, param_dict=self.params.param_dict,
                 ctx=self.mxnet_context, optimizer=optimizer,
-                learning_rate=learning_rate, max_iter=max_iter, verbose=verbose)
+                learning_rate=learning_rate, max_iter=max_iter, logger=logger)
+
 
 class GradTransferInference(GradBasedInference):
     """

--- a/mxfusion/inference/grad_based_inference.py
+++ b/mxfusion/inference/grad_based_inference.py
@@ -68,7 +68,7 @@ class GradBasedInference(Inference):
         return infr
 
     def run(self, optimizer='adam', learning_rate=1e-3, max_iter=2000,
-            **kwargs):
+            verbose=False, **kwargs):
         """
         Run the inference method.
 
@@ -78,6 +78,8 @@ class GradBasedInference(Inference):
         :type learning_rate: float
         :param max_iter: the maximum number of iterations of gradient optimization
         :type max_iter: int
+        :param verbose: whether to print per-iteration messages.
+        :type verbose: boolean
         :param kwargs: The keyword arguments specify the data for inferences. The key of each argument is the name of
         the corresponding variable in model definition and the value of the argument is the data in numpy array format.
         """
@@ -97,12 +99,12 @@ class GradBasedInference(Inference):
                 infr_executor=infr, data=data, param_dict=self.params.param_dict,
                 ctx=self.mxnet_context, optimizer=optimizer,
                 learning_rate=learning_rate, max_iter=max_iter,
-                update_shape_constants=update_shape_constants, logger=self._logger)
+                update_shape_constants=update_shape_constants, verbose=verbose, logger=self._logger)
         else:
             return self._grad_loop.run(
                 infr_executor=infr, data=data, param_dict=self.params.param_dict,
                 ctx=self.mxnet_context, optimizer=optimizer,
-                learning_rate=learning_rate, max_iter=max_iter, logger=self._logger)
+                learning_rate=learning_rate, max_iter=max_iter, verbose=verbose, logger=self._logger)
 
 
 class GradTransferInference(GradBasedInference):

--- a/mxfusion/inference/grad_based_inference.py
+++ b/mxfusion/inference/grad_based_inference.py
@@ -37,15 +37,17 @@ class GradBasedInference(Inference):
     :type dtype: {numpy.float64, numpy.float32, 'float64', 'float32'}
     :param context: The MXNet context
     :type context: {mxnet.cpu or mxnet.gpu}
+    :param logger: The logger to send logs to
+    :type logger: :class:`inference.Logger`
     """
 
     def __init__(self, inference_algorithm, grad_loop=None, constants=None,
-                 hybridize=False, dtype=None, context=None):
+                 hybridize=False, dtype=None, context=None, logger=None):
         if grad_loop is None:
             grad_loop = BatchInferenceLoop()
         super(GradBasedInference, self).__init__(
             inference_algorithm=inference_algorithm, constants=constants,
-            hybridize=hybridize, dtype=dtype, context=context)
+            hybridize=hybridize, dtype=dtype, context=context, logger=logger)
         self._grad_loop = grad_loop
 
     def create_executor(self):
@@ -66,7 +68,7 @@ class GradBasedInference(Inference):
         return infr
 
     def run(self, optimizer='adam', learning_rate=1e-3, max_iter=2000,
-            logger=None, **kwargs):
+            **kwargs):
         """
         Run the inference method.
 
@@ -76,8 +78,6 @@ class GradBasedInference(Inference):
         :type learning_rate: float
         :param max_iter: the maximum number of iterations of gradient optimization
         :type max_iter: int
-        :param logger: The logger to send logs to
-        :type logger: :class:`inference.Logger`
         :param kwargs: The keyword arguments specify the data for inferences. The key of each argument is the name of
         the corresponding variable in model definition and the value of the argument is the data in numpy array format.
         """
@@ -97,12 +97,12 @@ class GradBasedInference(Inference):
                 infr_executor=infr, data=data, param_dict=self.params.param_dict,
                 ctx=self.mxnet_context, optimizer=optimizer,
                 learning_rate=learning_rate, max_iter=max_iter,
-                update_shape_constants=update_shape_constants, logger=logger)
+                update_shape_constants=update_shape_constants, logger=self._logger)
         else:
             return self._grad_loop.run(
                 infr_executor=infr, data=data, param_dict=self.params.param_dict,
                 ctx=self.mxnet_context, optimizer=optimizer,
-                learning_rate=learning_rate, max_iter=max_iter, logger=logger)
+                learning_rate=learning_rate, max_iter=max_iter, logger=self._logger)
 
 
 class GradTransferInference(GradBasedInference):

--- a/mxfusion/inference/grad_loop.py
+++ b/mxfusion/inference/grad_loop.py
@@ -23,7 +23,7 @@ class GradLoop(ABC):
 
     @abstractmethod
     def run(self, infr_executor, data, param_dict, ctx, optimizer='adam',
-            learning_rate=1e-3, max_iter=2000, verbose=False):
+            learning_rate=1e-3, max_iter=2000, logger=None):
         """
         :param infr_executor: The MXNet function that computes the training objective.
         :type infr_executor: MXNet Gluon Block
@@ -39,7 +39,7 @@ class GradLoop(ABC):
         :type learning_rate: float
         :param max_iter: the maximum number of iterations of gradient optimization
         :type max_iter: int
-        :param verbose: whether to print per-iteration messages.
-        :type verbose: boolean
+        :param logger: The logger to send logs to
+        :type logger: :class:`inference.Logger`
         """
         pass

--- a/mxfusion/inference/grad_loop.py
+++ b/mxfusion/inference/grad_loop.py
@@ -23,7 +23,7 @@ class GradLoop(ABC):
 
     @abstractmethod
     def run(self, infr_executor, data, param_dict, ctx, optimizer='adam',
-            learning_rate=1e-3, max_iter=2000, logger=None):
+            learning_rate=1e-3, max_iter=2000, verbose=False, logger=None):
         """
         :param infr_executor: The MXNet function that computes the training objective.
         :type infr_executor: MXNet Gluon Block
@@ -39,6 +39,8 @@ class GradLoop(ABC):
         :type learning_rate: float
         :param max_iter: the maximum number of iterations of gradient optimization
         :type max_iter: int
+        :param verbose: whether to print per-iteration messages.
+        :type verbose: boolean
         :param logger: The logger to send logs to
         :type logger: :class:`inference.Logger`
         """

--- a/mxfusion/inference/inference.py
+++ b/mxfusion/inference/inference.py
@@ -22,6 +22,7 @@ import mxnet as mx
 import numpy as np
 
 from .inference_parameters import InferenceParameters
+from .logger import Logger
 from ..common.config import get_default_device, get_default_dtype
 from ..common.exceptions import InferenceError, SerializationError
 from ..models import FactorGraph, Model, Posterior
@@ -62,7 +63,7 @@ class Inference(object):
                                           dtype=self.dtype,
                                           context=self.mxnet_context)
         self._initialized = False
-        self._logger = logger
+        self._logger = Logger() if logger is None else logger
 
     def print_params(self):
         """

--- a/mxfusion/inference/inference.py
+++ b/mxfusion/inference/inference.py
@@ -13,19 +13,21 @@
 # ==============================================================================
 
 
-import warnings
 import io
 import json
-import numpy as np
-import mxnet as mx
+import warnings
 import zipfile
+
+import mxnet as mx
+import numpy as np
+
 from .inference_parameters import InferenceParameters
 from ..common.config import get_default_device, get_default_dtype
 from ..common.exceptions import InferenceError, SerializationError
-from ..util.inference import discover_shape_constants, init_outcomes
 from ..models import FactorGraph, Model, Posterior
+from ..util.inference import discover_shape_constants, init_outcomes
 from ..util.serialization import ModelComponentEncoder, make_numpy, load_json_from_zip, load_parameters, \
-                                 FILENAMES, DEFAULT_ZIP, ENCODINGS, SERIALIZATION_VERSION
+    FILENAMES, DEFAULT_ZIP, ENCODINGS, SERIALIZATION_VERSION
 
 
 class Inference(object):
@@ -45,10 +47,12 @@ class Inference(object):
     :type dtype: {numpy.float64, numpy.float32, 'float64', 'float32'}
     :param context: The MXNet context
     :type context: {mxnet.cpu or mxnet.gpu}
+    :param logger: The logger to send logs to
+    :type logger: :class:`inference.Logger`
     """
 
     def __init__(self, inference_algorithm, constants=None,
-                 hybridize=False, dtype=None, context=None):
+                 hybridize=False, dtype=None, context=None, logger=None):
         self.dtype = dtype if dtype is not None else get_default_dtype()
         self.mxnet_context = context if context is not None else get_default_device()
         self._hybridize = hybridize
@@ -58,6 +62,7 @@ class Inference(object):
                                           dtype=self.dtype,
                                           context=self.mxnet_context)
         self._initialized = False
+        self._logger = logger
 
     def print_params(self):
         """
@@ -68,6 +73,7 @@ class Inference(object):
         > infr.print_params()
         Variable(1ab23)(name=y) - (Model/Posterior(123ge2)) - (first mxnet values/shape)
         """
+
         def get_class_name(graph):
             if isinstance(graph, Model):
                 return "Model"
@@ -75,9 +81,10 @@ class Inference(object):
                 return "Posterior"
             else:
                 return "FactorGraph"
+
         string = ""
         for param_uuid, param in self.params.param_dict.items():
-            temp = [(graph,graph[param_uuid]) for i,graph in enumerate(self._graphs) if param_uuid in graph]
+            temp = [(graph, graph[param_uuid]) for i, graph in enumerate(self._graphs) if param_uuid in graph]
             graph, var_param = temp[0]
             string += "{} in {}({}) : {} \n\n".format(var_param, get_class_name(graph), graph._uuid[:5], param.data())
         return string
@@ -205,7 +212,7 @@ class Inference(object):
         # Load graphs
         from ..util.serialization import ModelComponentDecoder
         graphs_list = load_json_from_zip(zip_filename, FILENAMES['graphs'],
-                                           decoder=ModelComponentDecoder)
+                                         decoder=ModelComponentDecoder)
         graphs = FactorGraph.load_graphs(graphs_list)
         primary_model = graphs[0]
         secondary_graphs = graphs[1:]
@@ -272,7 +279,7 @@ class Inference(object):
         # Retrieve dictionary representations of things to save
         mxnet_parameters, mxnet_constants, variable_constants = self.params.get_serializable()
         configuration = self.get_serializable()
-        graphs = [g.as_json()for g in self._graphs]
+        graphs = [g.as_json() for g in self._graphs]
         version_dict = {"serialization_version": SERIALIZATION_VERSION}
 
         files_to_save = []
@@ -281,7 +288,7 @@ class Inference(object):
         ordered_filenames = [FILENAMES['graphs'], FILENAMES['mxnet_params'], FILENAMES['mxnet_constants'],
                              FILENAMES['variable_constants'], FILENAMES['configuration'], FILENAMES['version_file']]
         encodings = [ENCODINGS['json'], ENCODINGS['numpy'], ENCODINGS['numpy'],
-                             ENCODINGS['json'], ENCODINGS['json'], ENCODINGS['json']]
+                     ENCODINGS['json'], ENCODINGS['json'], ENCODINGS['json']]
 
         # Form each individual file buffer.
         for filename, obj, encoding in zip(ordered_filenames, objects, encodings):
@@ -327,6 +334,7 @@ class TransferInference(Inference):
     :param context: The MXNet context
     :type context: {mxnet.cpu or mxnet.gpu}
     """
+
     def __init__(self, inference_algorithm, infr_params, var_tie=None,
                  constants=None, hybridize=False, dtype=None, context=None):
         self._var_tie = var_tie if var_tie is not None else {}

--- a/mxfusion/inference/logger.py
+++ b/mxfusion/inference/logger.py
@@ -21,16 +21,13 @@ class Logger:
     """
     The class for logging the results of optimization.
 
-    :param boolean verbose: whether to print per-iteration messages
-    :param str log_dir: the directory in which to place the tensorboard logs directory. If this is not set then no
+    :param str log_dir: The directory in which to place the tensorboard logs directory. If this is not set then no
                         tensorboard logs will be written
-    :param str log_name: the directory in which to place tensoreboard logs. If no name is assigned, a timestamp name
+    :param str log_name: The directory in which to place tensorboard logs. If no name is assigned, a timestamp name
                          will be used.
     """
 
-    def __init__(self, verbose=True, log_dir=None, log_name=None):
-        self.verbose = verbose
-
+    def __init__(self, log_dir=None, log_name=None):
         self._validate_log_args(log_dir, log_name)
         self.log_dir = log_dir
         self.log_name = log_name
@@ -47,7 +44,8 @@ class Logger:
         """
         Open logger.
         """
-        self.summary_writer = self.log_dir and self._get_board(self.log_dir, self.log_name)
+        if self.log_dir:
+            self.summary_writer = self._get_board(self.log_dir, self.log_name)
         self._on_new_line = True
 
     def close(self):
@@ -80,7 +78,7 @@ class Logger:
 
         return SummaryWriter(Logger._get_board_path(log_dir, log_name))
 
-    def log(self, tag, value, step, iterate_name='Iteration', precision=3, newline=False):
+    def log(self, tag, value, step, iterate_name='Iteration', precision=3, newline=False, verbose=False):
         """
         Log value.
 
@@ -91,8 +89,9 @@ class Logger:
         :param str iterate_name: name of the iterate
         :param int precision: number of decimal places to show
         :param boolean newline: whether to terminate log with newline
+        :param boolean verbose: whether to print per-iteration messages
         """
-        if self.verbose:
+        if verbose:
             self._on_new_line = newline
             print('\r{} {} {}: {:.{precision}f}\t\t\t\t'.format(
                 iterate_name, step, tag, value, precision=precision), end='\n' if newline else '')
@@ -100,11 +99,13 @@ class Logger:
         if self.summary_writer is not None:
             self.summary_writer.add_scalar(tag=tag, value=value, global_step=step)
 
-    def flush(self):
+    def flush(self, verbose=False):
         """
         Flushes board writer and adds new line if not already on a new line.
+
+        :param boolean verbose: whether to print per-iteration messages
         """
-        if not self._on_new_line and self.verbose:
+        if not self._on_new_line and verbose:
             print()
         self._on_new_line = True
         if self.summary_writer:

--- a/mxfusion/inference/logger.py
+++ b/mxfusion/inference/logger.py
@@ -34,19 +34,23 @@ class Logger:
         self.verbose = verbose
 
         self._validate_log_args(log_dir, log_name)
-        self.summary_writer = log_dir and self._get_board(log_dir, log_name)
+        self.log_dir = log_dir
+        self.log_name = log_name
+
+        self.summary_writer = None
         self._on_new_line = True
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.close()
 
     @staticmethod
     def _validate_log_args(log_dir, log_name):
         if log_name and log_dir is None:
             raise ValueError("No log directory provided for MXBoard. Log name given: {}".format(log_name))
+
+    def open(self):
+        """
+        Open logger.
+        """
+        self.summary_writer = self.log_dir and self._get_board(self.log_dir, self.log_name)
+        self._on_new_line = True
 
     def close(self):
         """
@@ -58,7 +62,7 @@ class Logger:
 
     @staticmethod
     def _get_board_path(log_dir, log_name):
-        log_name = log_name or time.strftime("%Y%m%d-%H:%M:%S", time.localtime())
+        log_name = time.strftime("%Y%m%d-%H:%M:%S", time.localtime()) if log_name is None else log_name
 
         path = os.path.join(log_dir, log_name)
 

--- a/mxfusion/inference/logger.py
+++ b/mxfusion/inference/logger.py
@@ -16,8 +16,6 @@
 import os
 import time
 
-from mxboard import SummaryWriter
-
 
 class Logger:
     """
@@ -77,6 +75,9 @@ class Logger:
 
     @staticmethod
     def _get_board(log_dir, log_name):
+        # Only import mxboard if absolutely necessary
+        from mxboard import SummaryWriter
+
         return SummaryWriter(Logger._get_board_path(log_dir, log_name))
 
     def log(self, tag, value, step, iterate_name='Iteration', precision=3, newline=False):

--- a/mxfusion/inference/logger.py
+++ b/mxfusion/inference/logger.py
@@ -1,3 +1,18 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License").
+#   You may not use this file except in compliance with the License.
+#   A copy of the License is located at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   or in the "license" file accompanying this file. This file is distributed
+#   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+#   express or implied. See the License for the specific language governing
+#   permissions and limitations under the License.
+# ==============================================================================
+
+
 import os
 import time
 

--- a/mxfusion/inference/minibatch_loop.py
+++ b/mxfusion/inference/minibatch_loop.py
@@ -42,7 +42,7 @@ class MinibatchInferenceLoop(GradLoop):
             if rv_scaling is not None else rv_scaling
 
     def run(self, infr_executor, data, param_dict, ctx, optimizer='adam',
-            learning_rate=1e-3, max_iter=1000, update_shape_constants=None, logger=None):
+            learning_rate=1e-3, max_iter=1000, update_shape_constants=None, verbose=False, logger=None):
         """
         :param infr_executor: The MXNet function that computes the training objective.
         :type infr_executor: MXNet Gluon Block
@@ -58,10 +58,12 @@ class MinibatchInferenceLoop(GradLoop):
         :type learning_rate: float
         :param max_iter: the maximum number of iterations of gradient optimization
         :type max_iter: int
-        :param logger: The logger to send logs to
-        :type logger: :class:`inference.Logger`
         :param update_shape_constants: The callback function to update the shape constants according to the size of minibatch
         :type update_shape_constants: Python function
+        :param verbose: whether to print per-iteration messages.
+        :type verbose: boolean
+        :param logger: The logger to send logs to
+        :type logger: :class:`inference.Logger`
         """
 
         if logger:
@@ -92,14 +94,15 @@ class MinibatchInferenceLoop(GradLoop):
                     loss_for_gradient.backward()
 
                 if logger:
-                    logger.log(tag='loss', value=loss.asscalar(), step=batch_number + total_batches + 1)
+                    logger.log(tag='loss', value=loss.asscalar(), step=batch_number + total_batches + 1,
+                               verbose=verbose)
 
                 trainer.step(batch_size=self.batch_size, ignore_stale_grad=True)
                 epoch_loss += loss.asscalar()
 
             if logger:
                 logger.log(tag='epoch_loss', value=epoch_loss / batch_number,
-                           step=e + 1, iterate_name="Epoch", newline=True)
+                           step=e + 1, iterate_name="Epoch", newline=True, verbose=verbose)
             total_batches += batch_number
 
         if logger:

--- a/mxfusion/inference/minibatch_loop.py
+++ b/mxfusion/inference/minibatch_loop.py
@@ -42,7 +42,7 @@ class MinibatchInferenceLoop(GradLoop):
             if rv_scaling is not None else rv_scaling
 
     def run(self, infr_executor, data, param_dict, ctx, optimizer='adam',
-            learning_rate=1e-3, max_iter=1000, verbose=False, update_shape_constants=None, logger=None):
+            learning_rate=1e-3, max_iter=1000, update_shape_constants=None, logger=None):
         """
         :param infr_executor: The MXNet function that computes the training objective.
         :type infr_executor: MXNet Gluon Block

--- a/mxfusion/inference/minibatch_loop.py
+++ b/mxfusion/inference/minibatch_loop.py
@@ -64,6 +64,9 @@ class MinibatchInferenceLoop(GradLoop):
         :type update_shape_constants: Python function
         """
 
+        if logger:
+            logger.open()
+
         if isinstance(data, mx.gluon.data.DataLoader):
             data_loader = data
         else:
@@ -74,7 +77,8 @@ class MinibatchInferenceLoop(GradLoop):
 
         total_batches = 0
         for e in range(max_iter):
-            epoch_loss = batch_number = 0
+            epoch_loss = 0
+            batch_number = 0
 
             for batch_number, data_batch in enumerate(data_loader):
                 if not isinstance(data_batch, (list, tuple)):
@@ -97,3 +101,6 @@ class MinibatchInferenceLoop(GradLoop):
                 logger.log(tag='epoch_loss', value=epoch_loss / batch_number,
                            step=e + 1, iterate_name="Epoch", newline=True)
             total_batches += batch_number
+
+        if logger:
+            logger.close()

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -7,3 +7,4 @@ scipy>=1.1.0
 GPy>=1.9.6
 matplotlib
 mxnet>=1.3
+mxboard>=0.1.0

--- a/testing/inference/expectation_test.py
+++ b/testing/inference/expectation_test.py
@@ -57,9 +57,9 @@ class TestExpectationInference(object):
         infr = GradBasedInference(
             ExpectationScoreFunctionAlgorithm(m, observed, num_samples=10, target_variables=target_variables))
 
-        infr.run(max_iter=1, v2=v2, v3=v3, verbose=True)
+        infr.run(max_iter=1, v2=v2, v3=v3)
 
         infr2 = TransferInference(
             ExpectationAlgorithm(m, observed, num_samples=10, target_variables=target_variables), infr_params=infr.params)
 
-        infr2.run(max_iter=1, v2=v2, v3=v3, verbose=True)
+        infr2.run(max_iter=1, v2=v2, v3=v3)

--- a/testing/inference/forward_sampling_test.py
+++ b/testing/inference/forward_sampling_test.py
@@ -79,7 +79,6 @@ class ForwardSamplingTests(unittest.TestCase):
         alg = StochasticVariationalInference(num_samples=3, model=m, posterior=q, observed=observed)
         infr = GradBasedInference(inference_algorithm=alg, grad_loop=BatchInferenceLoop())
         infr.initialize(y=y_nd, x=x_nd)
-        infr._verbose = True
         infr.run(max_iter=2, learning_rate=1e-2, y=y_nd, x=x_nd)
 
         infr2 = VariationalPosteriorForwardSampling(10, [m.x], infr, [m.r])

--- a/testing/inference/logger_test.py
+++ b/testing/inference/logger_test.py
@@ -26,6 +26,7 @@ class LoggerTests(unittest.TestCase):
     """
     Test class that tests the MXFusion.inference.Logger methods.
     """
+
     def setUp(self):
         self.log_dir = 'log_dir'
         self.log_name = 'log_name'
@@ -64,40 +65,54 @@ class LoggerTests(unittest.TestCase):
 
     def test_verbose(self):
         f = io.StringIO()
-        with contextlib.redirect_stdout(f), Logger() as ll:
+        ll = Logger()
+        ll.open()
+        with contextlib.redirect_stdout(f):
             ll.log(self.tag, 404, 2)
+            ll.close()
         s = f.getvalue()
         assert s == '\rIteration 2 tag: 404.000\t\t\t\t\n'
 
     def test_verbose_multi(self):
         f = io.StringIO()
-        with contextlib.redirect_stdout(f), Logger() as ll:
+        ll = Logger()
+        ll.open()
+        with contextlib.redirect_stdout(f):
             ll.log(self.tag, 404, 2)
             ll.log(self.tag, 808, 3)
+            ll.close()
         s = f.getvalue()
         assert s == '\rIteration 2 tag: 404.000\t\t\t\t\rIteration 3 tag: 808.000\t\t\t\t\n'
 
     def test_verbose_multi_newline(self):
         f = io.StringIO()
-        with contextlib.redirect_stdout(f), Logger() as ll:
+        ll = Logger()
+        ll.open()
+        with contextlib.redirect_stdout(f):
             ll.log(self.tag, 404, 2, newline=True)
             ll.log(self.tag, 808, 3)
+            ll.close()
         s = f.getvalue()
         assert s == '\rIteration 2 tag: 404.000\t\t\t\t\n\rIteration 3 tag: 808.000\t\t\t\t\n'
 
     def test_board_log(self):
-        with Logger(verbose=False, log_dir=self.log_dir, log_name=self.log_name) as ll:
-            ll.log(self.tag, 404, 2)
+        ll = Logger(verbose=False, log_dir=self.log_dir, log_name=self.log_name)
+        ll.open()
+        ll.log(self.tag, 404, 2)
+        ll.close()
         path = os.path.join(self.log_dir, self.log_name)
         assert os.path.isdir(path)
         assert len(os.listdir(path)) == 1
 
     def test_flush(self):
         f = io.StringIO()
-        with contextlib.redirect_stdout(f), Logger() as ll:
+        ll = Logger()
+        ll.open()
+        with contextlib.redirect_stdout(f):
             ll._on_new_line = False
             print('\rabc', end='')
             ll.flush()
             print('\r123', end='')
+            ll.close()
         s = f.getvalue()
         assert s == '\rabc\n\r123'

--- a/testing/inference/logger_test.py
+++ b/testing/inference/logger_test.py
@@ -1,3 +1,18 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License").
+#   You may not use this file except in compliance with the License.
+#   A copy of the License is located at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   or in the "license" file accompanying this file. This file is distributed
+#   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+#   express or implied. See the License for the specific language governing
+#   permissions and limitations under the License.
+# ==============================================================================
+
+
 import contextlib
 import io
 import os

--- a/testing/inference/logger_test.py
+++ b/testing/inference/logger_test.py
@@ -68,7 +68,7 @@ class LoggerTests(unittest.TestCase):
         ll = Logger()
         ll.open()
         with contextlib.redirect_stdout(f):
-            ll.log(self.tag, 404, 2)
+            ll.log(self.tag, 404, 2, verbose=True)
             ll.close()
         s = f.getvalue()
         assert s == '\rIteration 2 tag: 404.000\t\t\t\t\n'
@@ -78,8 +78,8 @@ class LoggerTests(unittest.TestCase):
         ll = Logger()
         ll.open()
         with contextlib.redirect_stdout(f):
-            ll.log(self.tag, 404, 2)
-            ll.log(self.tag, 808, 3)
+            ll.log(self.tag, 404, 2, verbose=True)
+            ll.log(self.tag, 808, 3, verbose=True)
             ll.close()
         s = f.getvalue()
         assert s == '\rIteration 2 tag: 404.000\t\t\t\t\rIteration 3 tag: 808.000\t\t\t\t\n'
@@ -89,20 +89,33 @@ class LoggerTests(unittest.TestCase):
         ll = Logger()
         ll.open()
         with contextlib.redirect_stdout(f):
-            ll.log(self.tag, 404, 2, newline=True)
-            ll.log(self.tag, 808, 3)
+            ll.log(self.tag, 404, 2, newline=True, verbose=True)
+            ll.log(self.tag, 808, 3, verbose=True)
             ll.close()
         s = f.getvalue()
         assert s == '\rIteration 2 tag: 404.000\t\t\t\t\n\rIteration 3 tag: 808.000\t\t\t\t\n'
 
     def test_board_log(self):
-        ll = Logger(verbose=False, log_dir=self.log_dir, log_name=self.log_name)
+        ll = Logger(log_dir=self.log_dir, log_name=self.log_name)
         ll.open()
-        ll.log(self.tag, 404, 2)
+        ll.log(self.tag, 404, 2, verbose=False)
         ll.close()
         path = os.path.join(self.log_dir, self.log_name)
         assert os.path.isdir(path)
         assert len(os.listdir(path)) == 1
+
+    def test_flush_verbose(self):
+        f = io.StringIO()
+        ll = Logger()
+        ll.open()
+        with contextlib.redirect_stdout(f):
+            ll._on_new_line = False
+            print('\rabc', end='')
+            ll.flush(verbose=True)
+            print('\r123', end='')
+            ll.close()
+        s = f.getvalue()
+        assert s == '\rabc\n\r123'
 
     def test_flush(self):
         f = io.StringIO()
@@ -111,8 +124,8 @@ class LoggerTests(unittest.TestCase):
         with contextlib.redirect_stdout(f):
             ll._on_new_line = False
             print('\rabc', end='')
-            ll.flush()
+            ll.flush(verbose=False)
             print('\r123', end='')
             ll.close()
         s = f.getvalue()
-        assert s == '\rabc\n\r123'
+        assert s == '\rabc\r123'

--- a/testing/inference/logger_test.py
+++ b/testing/inference/logger_test.py
@@ -1,0 +1,88 @@
+import contextlib
+import io
+import os
+import shutil
+import unittest
+
+from mxfusion.inference.logger import Logger
+
+
+class LoggerTests(unittest.TestCase):
+    """
+    Test class that tests the MXFusion.inference.Logger methods.
+    """
+    def setUp(self):
+        self.log_dir = 'log_dir'
+        self.log_name = 'log_name'
+        self.tag = 'tag'
+
+    def tearDown(self):
+        if self.log_dir in os.listdir():
+            shutil.rmtree(self.log_dir)
+
+    def test_validate_log_args(self):
+        Logger._validate_log_args(self.log_dir, self.log_name)
+        Logger._validate_log_args(self.log_dir, None)
+        Logger._validate_log_args(None, None)
+
+        with self.assertRaises(ValueError):
+            Logger._validate_log_args(None, self.log_name)
+
+    def test_get_board_path__no_log_name(self):
+        path = Logger._get_board_path(self.log_dir, None)
+
+        assert path.startswith(self.log_dir)
+        assert len(path) == 25, len(path)
+
+    def test_get_board_path__with_log_name(self):
+        path = Logger._get_board_path(self.log_dir, self.log_name)
+
+        assert path == self.log_dir + '/' + self.log_name, path
+
+        assert os.path.isdir(path)
+
+    def test_get_board_path__duplicates(self):
+        path1 = Logger._get_board_path(self.log_dir, self.log_name)
+        path2 = Logger._get_board_path(self.log_dir, self.log_name)
+
+        assert path1 != path2
+
+    def test_verbose(self):
+        f = io.StringIO()
+        with contextlib.redirect_stdout(f), Logger() as ll:
+            ll.log(self.tag, 404, 2)
+        s = f.getvalue()
+        assert s == '\rIteration 2 tag: 404.000\t\t\t\t\n'
+
+    def test_verbose_multi(self):
+        f = io.StringIO()
+        with contextlib.redirect_stdout(f), Logger() as ll:
+            ll.log(self.tag, 404, 2)
+            ll.log(self.tag, 808, 3)
+        s = f.getvalue()
+        assert s == '\rIteration 2 tag: 404.000\t\t\t\t\rIteration 3 tag: 808.000\t\t\t\t\n'
+
+    def test_verbose_multi_newline(self):
+        f = io.StringIO()
+        with contextlib.redirect_stdout(f), Logger() as ll:
+            ll.log(self.tag, 404, 2, newline=True)
+            ll.log(self.tag, 808, 3)
+        s = f.getvalue()
+        assert s == '\rIteration 2 tag: 404.000\t\t\t\t\n\rIteration 3 tag: 808.000\t\t\t\t\n'
+
+    def test_board_log(self):
+        with Logger(verbose=False, log_dir=self.log_dir, log_name=self.log_name) as ll:
+            ll.log(self.tag, 404, 2)
+        path = os.path.join(self.log_dir, self.log_name)
+        assert os.path.isdir(path)
+        assert len(os.listdir(path)) == 1
+
+    def test_flush(self):
+        f = io.StringIO()
+        with contextlib.redirect_stdout(f), Logger() as ll:
+            ll._on_new_line = False
+            print('\rabc', end='')
+            ll.flush()
+            print('\r123', end='')
+        s = f.getvalue()
+        assert s == '\rabc\n\r123'

--- a/testing/inference/pilco_test.py
+++ b/testing/inference/pilco_test.py
@@ -86,7 +86,7 @@ class TestPILCOInference(object):
         return X, Y
 
 
-    def fit_model(self, state_list, action_list, win_in, verbose=True, max_iter=1000):
+    def fit_model(self, state_list, action_list, win_in, max_iter=1000):
         """
         Fits a Gaussian Process model to the state / action pairs passed in.
         This creates a model of the environment which is used during
@@ -112,14 +112,14 @@ class TestPILCOInference(object):
             inference_algorithm=MAP(model=m, observed=[m.X, m.Y]))
         infr.run(X=mx.nd.array(X),
                  Y=mx.nd.array(Y),
-                 max_iter=max_iter, learning_rate=0.1, verbose=verbose)
+                 max_iter=max_iter, learning_rate=0.1)
         return m, infr, X, Y
 
     def optimize_policy(self, alg, policy, cost_func, model, infr,
                         model_data_X, model_data_Y,
                         initial_state_generator, num_grad_steps,
                         learning_rate=1e-2, num_time_steps=100,
-                        num_samples=10, verbose=True):
+                        num_samples=10):
         """
         Takes as primary inputs a policy, cost function, and trained model.
         Optimizes the policy for num_grad_steps number of iterations.
@@ -137,7 +137,7 @@ class TestPILCOInference(object):
             max_iter=num_grad_steps,
             X=mx.nd.array(model_data_X),
             Y=mx.nd.array(model_data_Y),
-            verbose=verbose, learning_rate=learning_rate)
+            learning_rate=learning_rate)
         return policy
 
     def initial_state_generator(self, num_initial_states, obs_space_shape=3):
@@ -173,7 +173,7 @@ class TestPILCOInference(object):
 
             # Fit a model.
             model, infr, model_data_X, model_data_Y = self.fit_model(
-                all_states, all_actions, win_in=1, verbose=True, max_iter=5)
+                all_states, all_actions, win_in=1, max_iter=5)
 
             # Optimize the policy.
             policy = self.optimize_policy(pilco_alg,

--- a/testing/inference/score_function_test.py
+++ b/testing/inference/score_function_test.py
@@ -118,7 +118,7 @@ class TestScoreFunction(object):
 
         infr = GradBasedInference(inference_algorithm=alg,  grad_loop=BatchInferenceLoop())
         infr.initialize(x=mx.nd.array(x_train, dtype=dtype))
-        infr.run(max_iter=1, learning_rate=1e-2, x=mx.nd.array(x_train, dtype=dtype), verbose=False)
+        infr.run(max_iter=1, learning_rate=1e-2, x=mx.nd.array(x_train, dtype=dtype))
         return infr, q.post_mean
 
     def test_score_function_batch(self):

--- a/testing/modules/sparsegpregression_test.py
+++ b/testing/modules/sparsegpregression_test.py
@@ -306,7 +306,7 @@ class TestSparseGPRegressionModule(object):
             inference_algorithm=StochasticVariationalInference(
                 model=m, posterior=q, num_samples=10, observed=[m.Y]))
         infr.run(Y=mx.nd.array(Y, dtype='float64'), max_iter=2,
-                 learning_rate=0.1, verbose=True)
+                 learning_rate=0.1)
 
         infr2 = Inference(ForwardSamplingAlgorithm(
             model=m, observed=[m.X], num_samples=5))


### PR DESCRIPTION
*Description of changes:*
* Added logging class to handle printing logs for optimisations.  This class can also write logs consumable by [TensorBoard](https://www.tensorflow.org/guide/summaries_and_tensorboard) using [MXBoard](https://github.com/awslabs/mxboard).
* Modified `BatchInferenceLoop` and `MiniBatchInferenceLoop` to use this logging class. The new class brings a change in the API by replacing the verbose argument with a logger argument in `run()`.

Contribution from myself and @DavidJanz

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.