### PR TITLE
Add A new operator to allow transparent usage of score function gradient estimator

### DIFF
--- a/docs/design_proposals/design-4_score_function_operator.md
+++ b/docs/design_proposals/design-4_score_function_operator.md
@@ -1,0 +1,61 @@
+# A new operator to allow transparent usage of score function variational inference
+
+Zhenwen Dai (2019-06-07)
+
+## Motivation
+
+A significant portion of stochastic variational inference (SVI) methods are developed based on the score function approach. Different from SVI with reparameterizable distributions, when applying a score function method, the gradient estimators for the variational posterior and the model parameters follow two separate formulation. Let $p(y, x | \theta)$ be the prior distribution of a probabilistic model, where $y$ is the observed variable, $x$ is the latent variable and $\theta$ is the parameters of the model. Let $q_{\phi}(x)$ be the variational posterior of $x$. With Monte Carlo sampling, the variationa lower bound is approximated by
+$$
+\mathcal{L} \approx \frac{1}{N}\sum_{i} \log \frac{p(y, x_i|\theta)}{q_{\phi}(x_i)}, \quad x_i \sim q_{\phi}(x),
+$$
+where $N$ is the number of drawn samples for $x$. For a non-reparameterizable distribution, the gradient with respect to $\phi$ cannot be obtained through samples $x_i$. When applying a score function method, we need to separate the gradient estimator for $\theta$ and $\phi$, i.e.,
+$$
+\nabla_{\theta} \mathcal{L} \approx \frac{1}{N}\sum_{i}  \nabla_{\theta} \log p(y, x_i|\theta),
+$$
+$$
+\nabla_{\phi} \mathcal{L} \approx \frac{1}{N}\sum_{i} \log p(y, x_i|\theta) \nabla_{\phi} \log  q_{\phi}(x_i).
+$$
+The gradient estimators for $\theta$ and $\phi$ are very different. To facilitate auto-differentiation for both $\theta$ and $\phi$ with a single objective function, we can derive the following training objective by using the stop gradient operator,
+$$
+\mathcal{O} = \frac{1}{N}\sum_{i} \log p(y, x_i|\theta) + \mathcal{S}\left(\log p(y, x_i|\theta)\right) \log  q_{\phi}(x_i)
+$$
+where $\mathcal{S}(\cdot)$ is the stop gradient operator, which stops the auto-differentiation from going into the input of the operator. This is the currently implementation of the score function inference algorithm, but the limitation is that this objective cannot be consumed by any downstream calculation because the value does not correspond to the correct expectation as shown in the first equation.   
+
+To allow the score function method to be used transparently in PPL, we need the outcome of the score function method to be $\mathcal{L}$ and, when performing auto-differentiation, the gradient should be estimated from $\mathcal{O}$.
+
+
+## Proposed Changes
+
+To address the above challenge, we propose a new operator that enable the separation of the forward and backward behavior in auto-differentiation. If we abstract the pattern of the forward and backward calculation in the above challenge, we get a function $l(p, q)$ depends on two variables $p$ and $q$. The forward calculation of the function is
+$$
+l(p, q) = p,
+$$
+and the backward calculation is
+$$
+\frac{\partial o}{\partial p} = \frac{\partial o}{\partial l}, \quad \frac{\partial o}{\partial q} = \frac{\partial o}{\partial l} p,
+$$
+where $o$ is the scalar final objective of the whole auto-differentiation.
+
+We can implement the above operator as a MXNet customer operator such as
+```python
+def score_func_grad(p, q):
+    ...
+```
+
+The score function variational inference can be implemented as
+```python
+import mxnet as mx
+
+x_samples = q_x.draw_samples()
+log_p = model.log_pdf(x_samples, y)
+log_q = q_x.log_pdf(x_samples)
+bound = mx.nd.mean(score_func_grad(log_p, log_q) - mx.nd.BlockGrad(log_q))
+```
+
+## Rejected Alternatives
+
+I haven't seen an alternative solution yet.
+
+## Reference
+
+Cox, D. R.; Hinkley, D. V. (1974). Theoretical Statistics. Chapman & Hall. ISBN 0-412-12420-3.

--- a/mxfusion/inference/score_function.py
+++ b/mxfusion/inference/score_function.py
@@ -74,7 +74,7 @@ class ScoreFunctionInference(StochasticVariationalInference):
 
         bound = mx.nd.mean(score_func_grad(p_x_z, q_z_lambda) - mx.nd.BlockGrad(q_z_lambda))
 
-        return -bound
+        return -bound, -bound
 
 
 class ScoreFunctionRBInference(ScoreFunctionInference):
@@ -153,8 +153,7 @@ class ScoreFunctionRBInference(ScoreFunctionInference):
             # Need to stop the gradient of p_i manually, for some reason it doesn't like
             # being used directly in this computation. Possibly only when p_i == p_x_z but
             # that is unconfirmed.
-            # f_i = q_i * (p_i.asscalar() - q_i.asscalar())
-            f_i = score_func_grad(p_i, q_i)
+            f_i = q_i * (p_i.asscalar() - q_i.asscalar())
 
             # f_i = q_i * F.stop_gradient(p_i - q_i)
             f_list.append(F.expand_dims(f_i, axis=0))
@@ -174,7 +173,7 @@ class ScoreFunctionRBInference(ScoreFunctionInference):
         # Robbins-Monro sequence??
         gradient_log_L = gradient_lambda + gradient_theta
 
-        return -gradient_theta
+        return -gradient_theta, -gradient_log_L
 
     def _extract_descendant_blanket_params(self, graph, node):
         """

--- a/mxfusion/util/customop.py
+++ b/mxfusion/util/customop.py
@@ -148,9 +148,9 @@ def broadcast_to_w_samples(F, data, shape, isSamples=True):
                         isSamples=isSamples, shape=shape)
 
 
-class ScoreFuncGradlOp(mx.operator.CustomOp):
+class ScoreFuncGradOp(mx.operator.CustomOp):
     def __init__(self, **kwargs):
-        super(ScoreFuncGradlOp, self).__init__(**kwargs)
+        super(ScoreFuncGradOp, self).__init__(**kwargs)
 
     def forward(self, is_train, req, in_data, out_data, aux):
         self.assign(out_data[0], req[0], in_data[0])
@@ -161,9 +161,9 @@ class ScoreFuncGradlOp(mx.operator.CustomOp):
 
 
 @mx.operator.register("score_func_grad")
-class ScoreFuncGradlOpProp(mx.operator.CustomOpProp):
+class ScoreFuncGradOpProp(mx.operator.CustomOpProp):
     def __init__(self):
-        super(ScoreFuncGradlOpProp, self).__init__(need_top_grad=True)
+        super(ScoreFuncGradOpProp, self).__init__(need_top_grad=True)
 
     def list_arguments(self):
         return ['p', 'q']
@@ -175,7 +175,7 @@ class ScoreFuncGradlOpProp(mx.operator.CustomOpProp):
         return in_shape, (in_shape[0],), ()
 
     def create_operator(self, ctx, shapes, dtypes, **kwargs):
-        return ScoreFuncGradlOp(**kwargs)
+        return ScoreFuncGradOp(**kwargs)
 
 
 def score_func_grad(p, q, name="score_func_grad"):

--- a/mxfusion/util/customop.py
+++ b/mxfusion/util/customop.py
@@ -146,3 +146,37 @@ def broadcast_to_w_samples(F, data, shape, isSamples=True):
     else:
         return F.Custom(data, op_type="broadcast_to_w_samples",
                         isSamples=isSamples, shape=shape)
+
+
+class ScoreFuncGradlOp(mx.operator.CustomOp):
+    def __init__(self, **kwargs):
+        super(ScoreFuncGradlOp, self).__init__(**kwargs)
+
+    def forward(self, is_train, req, in_data, out_data, aux):
+        self.assign(out_data[0], req[0], in_data[0])
+
+    def backward(self, req, out_grad, in_data, out_data, in_grad, aux):
+        self.assign(in_grad[0], req[0], out_grad[0])
+        self.assign(in_grad[1], req[1], out_grad[0]*in_data[0])
+
+
+@mx.operator.register("score_func_grad")
+class ScoreFuncGradlOpProp(mx.operator.CustomOpProp):
+    def __init__(self):
+        super(ScoreFuncGradlOpProp, self).__init__(need_top_grad=True)
+
+    def list_arguments(self):
+        return ['p', 'q']
+
+    def list_outputs(self):
+        return ['l']
+
+    def infer_shape(self, in_shape):
+        return in_shape, (in_shape[0],), ()
+
+    def create_operator(self, ctx, shapes, dtypes, **kwargs):
+        return ScoreFuncGradlOp(**kwargs)
+
+
+def score_func_grad(p, q, name="score_func_grad"):
+    return mx.nd.Custom(p, q, name=name, op_type="score_func_grad")

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,3 +29,6 @@ directory = build/documentation/coverage
 
 [coverage:xml]
 output = build/documentation/coverage/coverage.xml
+
+[flake8]
+max-line-length = 159


### PR DESCRIPTION
A score function gradient estimator is difficult because the estimator for the sampling distribution is different from the estimator for the expectation term. We introduce a customer operator to unify the interface so that auto-differentiation can be done transparently.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
