### PR TITLE
Copy over module algorithms correctly

### DIFF
--- a/mxfusion/modules/module.py
+++ b/mxfusion/modules/module.py
@@ -427,9 +427,9 @@ class Module(Factor):
                 graphs_index = {g: i for i,g in enumerate(self._extra_graphs)}
                 extra_graphs = [replicant._extra_graphs[graphs_index[graph]] for graph in algorithm.graphs
                                 if graph in graphs_index]
-                algs[conditionals] = (targets,
+                algs[conditionals] = [(targets,
                                       algorithm.replicate_self(replicant._module_graph, extra_graphs),
-                                      alg_name)
+                                      alg_name)]
         return algs
 
     def reconcile_with_module(self, previous_module):

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -8,4 +8,4 @@ GPy>=1.9.6
 matplotlib
 mxnet>=1.3
 mxboard>=0.1.0
-mock
+mock>=3.0.5

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -8,3 +8,4 @@ GPy>=1.9.6
 matplotlib
 mxnet>=1.3
 mxboard>=0.1.0
+mock

--- a/testing/modules/module_test.py
+++ b/testing/modules/module_test.py
@@ -1,0 +1,30 @@
+import mock
+
+from mxfusion import Variable
+from mxfusion.inference.inference_alg import SamplingAlgorithm
+from mxfusion.models import Model
+from mxfusion.modules.module import Module
+
+
+def test_module_clone_algorithms():
+    m = Model()
+    m.X = Variable()
+    m.Y = Variable()
+
+    module = Module([('X', m.X)], [('Y', m.Y)], ['in'], 'out')
+    module._module_graph = Model()
+
+    sampling_alg = mock.create_autospec(SamplingAlgorithm)
+    sampling_alg.replicate_self.return_value = sampling_alg
+    module.attach_draw_samples_algorithms([m.Y], [m.X], sampling_alg)
+
+    cloned_module = module.replicate_self()
+
+    # Check dictionary contains 1 entry
+    assert len(cloned_module._draw_samples_algorithms) == 1
+    # Check dictionary key is a tuple containing m.X
+    assert list(cloned_module._draw_samples_algorithms.keys())[0] == (m.X, )
+    # Check dictionary value is a list containing a tuple with 3 entries
+    assert isinstance(cloned_module._draw_samples_algorithms[(m.X,)], list)
+    assert isinstance(cloned_module._draw_samples_algorithms[(m.X,)][0], tuple)
+    assert len(cloned_module._draw_samples_algorithms[(m.X,)][0]) == 3


### PR DESCRIPTION
The module algorithms dictionary is expected to be a list containing tuples but after cloning a module this is not the case. This PR fixes that.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
