### PR TITLE
Fix issue #190 and #191

### DIFF
--- a/mxfusion/components/distributions/gp/kernels/multiply_kernel.py
+++ b/mxfusion/components/distributions/gp/kernels/multiply_kernel.py
@@ -30,7 +30,7 @@ class MultiplyKernel(CombinationKernel):
     :param ctx: the mxnet context (default: None/current context).
     :type ctx: None or mxnet.cpu or mxnet.gpu
     """
-    def __init__(self, sub_kernels, name='add', dtype=None, ctx=None):
+    def __init__(self, sub_kernels, name='mul', dtype=None, ctx=None):
         kernels = []
         for k in sub_kernels:
             if isinstance(k, CombinationKernel):

--- a/mxfusion/inference/minibatch_loop.py
+++ b/mxfusion/inference/minibatch_loop.py
@@ -73,11 +73,11 @@ class MinibatchInferenceLoop(GradLoop):
         if isinstance(data, mx.gluon.data.DataLoader):
             data_loader = data
         else:
-            if (self.batch_size > len(data)):
+            if (self.batch_size > len(ArrayDataset(*data))):
                 warnings.warn(
-                    "'batch_size' set to default=100. 'batch_size' cannot be greater than observed variables.",
+                    "The requested batch_size is more than the length of the data passed in. Using batch_size as the size of the data instead.",
                     category=UserWarning)
-                load_batch_size = 100
+                load_batch_size = len(ArrayDataset(*data))
             else:
                 load_batch_size = self.batch_size
 
@@ -92,7 +92,7 @@ class MinibatchInferenceLoop(GradLoop):
             epoch_loss = 0
             batch_number = 0
 
-            for batch_number, data_batch in enumerate(data_loader):
+            for batch_number, data_batch in enumerate(data_loader,1):
                 if not isinstance(data_batch, (list, tuple)):
                     data_batch = [data_batch]
 
@@ -109,7 +109,6 @@ class MinibatchInferenceLoop(GradLoop):
 
                 trainer.step(batch_size=self.batch_size, ignore_stale_grad=True)
                 epoch_loss += loss.asscalar()
-                batch_number += 1
 
             if logger:
                 logger.log(tag='epoch_loss', value=epoch_loss / batch_number,


### PR DESCRIPTION
*Issue #, if available:*
1. minibatch_loop.py: logger.log(tag='epoch_loss', value=epoch_loss / batch_number, step=e + 1, iterate_name="Epoch", newline=True, verbose=verbose). 'value' always return inf due to batch_number = 0. #191 
2. batch_number did not display correctly, start from 0 instead of 1.
3. Default 'name' of MultiplyKernel class is 'add'. #190 

*Description of changes:*
1. issue a warning that batch_size cannot be lesser than size of dataset. set batch_size to size of data.
2. change from enumerate(data_loader) to enumerate(data_loader,1)
3. change 'add' to 'mul'.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.