### PR TITLE
Bump requirement to numpy>=1.16 to fix build fail.

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
 networkx>=2.1
-numpy>=1.7
+numpy>=1.16
 # mxnet
 # While MXFusion depends on MXNet, there are multiple versions in PyPi for GPU/MKL that are better managed by the user than in this requirements file.

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -6,6 +6,6 @@ pytest-cov>=2.5.1
 scipy>=1.1.0
 GPy>=1.9.6
 matplotlib
-mxnet>=1.3
+mxnet>=1.5.0b20190613
 mxboard>=0.1.0
 mock>=3.0.5


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
